### PR TITLE
fix: shared view links showing empty page

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -198,7 +198,7 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
 
             // Yjs doc is empty — try to bootstrap from HTTP
             Promise.race([
-                adapter.getNote(noteId).catch(() => null),
+                adapter.getNote(noteId, shareToken).catch(() => null),
                 new Promise((r) => setTimeout(() => r(null), 500)),
             ]).then((data: any) => {
                 if (cancelled) return;

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -110,7 +110,7 @@ export interface NottyAdapter {
 
     // Notes
     getNotes(): Promise<Note[]>;
-    getNote(id: string): Promise<Note | null>;
+    getNote(id: string, shareToken?: string): Promise<Note | null>;
     getNoteMeta(id: string, shareToken?: string): Promise<Partial<Note> | null>;
     saveNote(id: string, title: string, content: string, folderId?: string | null): void;
     deleteNote(id: string): Promise<void>;

--- a/src/lib/web-adapter.ts
+++ b/src/lib/web-adapter.ts
@@ -98,9 +98,10 @@ export class WebAdapter implements NottyAdapter {
         }
     }
 
-    async getNote(id: string): Promise<Note | null> {
+    async getNote(id: string, shareToken?: string): Promise<Note | null> {
         try {
-            const res = await fetch(`/api/notes/${id}`);
+            const params = shareToken ? `?share=${encodeURIComponent(shareToken)}` : "";
+            const res = await fetch(`/api/notes/${id}${params}`);
             if (res.status === 404) return null;
             await assertOk(res, "Failed to fetch note");
             return res.json();

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -64,7 +64,8 @@ export class NottyProvider {
     }
 
     connect() {
-        if (this.destroyed || this.offlineOnly) return;
+        if (this.destroyed) return;
+        this.offlineOnly = false;
         let wsUrl: string;
         if (this.serverUrl) {
             const proto = this.serverUrl.startsWith("https") ? "wss:" : "ws:";


### PR DESCRIPTION
## Summary
- Fixed WebSocket provider never connecting for web users — `connect: false` (deferred connect) was permanently blocking connections via `offlineOnly` flag
- Fixed HTTP bootstrap fallback not passing share token, causing 404 for non-owners opening shared links

## Test plan
- [ ] Generate a view link for a note with content
- [ ] Open the link in an incognito browser
- [ ] Verify the note content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)