### PR TITLE
fix: sync content from Yjs edits for shared editing

### DIFF
--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -156,10 +156,22 @@ export class UserNotesDurableObject extends DurableObject {
             this.saveTimers.set(noteId, setTimeout(() => {
                 try {
                     const state = Y.encodeStateAsUpdate(doc!);
-                    this.sql.exec(
-                        "UPDATE notes SET yjs_state = ?, updated_at = unixepoch() WHERE id = ?",
-                        state, noteId
-                    );
+                    // Also sync content + title columns so HTTP reads stay fresh
+                    const content = this.extractContentJson(noteId);
+                    if (content) {
+                        const parsed = JSON.parse(content);
+                        const firstNode = parsed?.content?.[0];
+                        const title = firstNode?.content?.map((n: any) => n.text || "").join("").trim() || "Untitled";
+                        this.sql.exec(
+                            "UPDATE notes SET yjs_state = ?, content = ?, title = ?, updated_at = unixepoch() WHERE id = ?",
+                            state, content, title, noteId
+                        );
+                    } else {
+                        this.sql.exec(
+                            "UPDATE notes SET yjs_state = ?, updated_at = unixepoch() WHERE id = ?",
+                            state, noteId
+                        );
+                    }
                 } catch (e) {
                     console.error(`Failed to persist Yjs state for note ${noteId}:`, e);
                 }


### PR DESCRIPTION
## Summary
- When shared users edit via Yjs WebSocket, only `yjs_state` was persisted — the `content` and `title` columns were never updated
- This meant the owner's notes list, HTTP bootstrap, and search all showed stale content
- Now the Yjs debounced save timer also extracts TipTap JSON from the Yjs doc and updates `content`/`title` alongside `yjs_state`

## Test plan
- [ ] Open a note, generate an edit share link
- [ ] Open the link in incognito and make edits
- [ ] Refresh the main browser — verify the edits appear
- [ ] Verify real-time sync works (both users see changes live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)