### PR TITLE
feat: OG image previews for shared notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@better-auth/passkey": "^1.5.6",
 				"@dotenvx/dotenvx": "^1.59.1",
+				"@resvg/resvg-wasm": "^2.6.2",
 				"@tailwindcss/typography": "^0.5.19",
 				"@tailwindcss/vite": "^4.2.2",
 				"@tauri-apps/api": "^2.10.1",
@@ -28,6 +29,7 @@
 				"react": "19.1.5",
 				"react-dom": "19.1.5",
 				"react-router": "^7.14.0",
+				"satori": "^0.26.0",
 				"sonner": "^2.0.7",
 				"use-debounce": "^10.1.1",
 				"vaul": "^1.1.2",
@@ -2093,6 +2095,15 @@
 			"integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
 			"license": "MIT"
 		},
+		"node_modules/@resvg/resvg-wasm": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.6.2.tgz",
+			"integrity": "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==",
+			"license": "MPL-2.0",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.0.0-rc.13",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
@@ -2367,6 +2378,22 @@
 			"license": "MIT",
 			"dependencies": {
 				"@daybrush/utils": "^1.4.0"
+			}
+		},
+		"node_modules/@shuding/opentype.js": {
+			"version": "1.4.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+			"integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+			"license": "MIT",
+			"dependencies": {
+				"fflate": "^0.7.3",
+				"string.prototype.codepointat": "^0.2.1"
+			},
+			"bin": {
+				"ot": "bin/ot"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/@simplewebauthn/browser": {
@@ -3706,6 +3733,15 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+			"integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/better-auth": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.0.tgz",
@@ -3845,6 +3881,15 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/camelize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3903,6 +3948,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -3977,6 +4028,36 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-background-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+			"integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+			"license": "MIT"
+		},
+		"node_modules/css-box-shadow": {
+			"version": "1.0.0-3",
+			"resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+			"integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+			"license": "MIT"
+		},
+		"node_modules/css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/css-gradient-parser": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+			"integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/css-styled": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/css-styled/-/css-styled-1.0.8.tgz",
@@ -3994,6 +4075,17 @@
 			"dependencies": {
 				"@daybrush/utils": "^1.13.0",
 				"@scena/matrix": "^1.0.0"
+			}
+		},
+		"node_modules/css-to-react-native": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"node_modules/cssesc": {
@@ -4779,6 +4871,15 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/emoji-regex-xs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+			"integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.20.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -4813,6 +4914,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -4887,6 +4994,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+			"integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+			"license": "MIT"
 		},
 		"node_modules/framework-utils": {
 			"version": "1.1.0",
@@ -4996,6 +5109,18 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hex-rgb": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+			"integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/highlight.js": {
@@ -5515,6 +5640,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/linebreak": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+			"integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "0.0.8",
+				"unicode-trie": "^2.0.0"
 			}
 		},
 		"node_modules/linkify-it": {
@@ -6429,6 +6564,22 @@
 				"@daybrush/utils": "^1.7.1"
 			}
 		},
+		"node_modules/pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-css-color": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+			"integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^1.1.4",
+				"hex-rgb": "^4.1.0"
+			}
+		},
 		"node_modules/parse-entities": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6535,6 +6686,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"license": "MIT"
 		},
 		"node_modules/property-information": {
 			"version": "7.1.0",
@@ -7053,6 +7210,28 @@
 			"integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
 			"license": "MIT"
 		},
+		"node_modules/satori": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+			"integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+			"license": "MPL-2.0",
+			"dependencies": {
+				"@shuding/opentype.js": "1.4.0-beta.0",
+				"css-background-parser": "^0.1.0",
+				"css-box-shadow": "1.0.0-3",
+				"css-gradient-parser": "^0.0.17",
+				"css-to-react-native": "^3.0.0",
+				"emoji-regex-xs": "^2.0.1",
+				"escape-html": "^1.0.3",
+				"linebreak": "^1.1.0",
+				"parse-css-color": "^0.2.1",
+				"postcss-value-parser": "^4.2.0",
+				"yoga-layout": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.26.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -7218,6 +7397,12 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/string.prototype.codepointat": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+			"integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+			"license": "MIT"
+		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7303,6 +7488,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/tiny-inflate": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",
@@ -7937,6 +8128,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"pathe": "^2.0.3"
+			}
+		},
+		"node_modules/unicode-trie": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+			"integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^0.2.5",
+				"tiny-inflate": "^1.0.0"
 			}
 		},
 		"node_modules/unified": {
@@ -8905,6 +9106,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/yoga-layout": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+			"license": "MIT"
 		},
 		"node_modules/youch": {
 			"version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@better-auth/passkey": "^1.5.6",
 		"@dotenvx/dotenvx": "^1.59.1",
+		"@resvg/resvg-wasm": "^2.6.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.2.2",
 		"@tauri-apps/api": "^2.10.1",
@@ -32,6 +33,7 @@
 		"react": "19.1.5",
 		"react-dom": "19.1.5",
 		"react-router": "^7.14.0",
+		"satori": "^0.26.0",
 		"sonner": "^2.0.7",
 		"use-debounce": "^10.1.1",
 		"vaul": "^1.1.2",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { renderPublicPage, renderPublicNote } from "./public-page";
 import { renderRSS } from "./rss";
+import { generateOgImage } from "./og-image";
 
 export { AuthDurableObject } from "../durable-objects/auth";
 export { UserNotesDurableObject } from "../durable-objects/user-notes";
@@ -82,6 +83,10 @@ app.get("*", async (c, next) => {
 
     return c.text("Not found", 404);
 });
+
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
 
 // --- Auth helpers ---
 
@@ -524,17 +529,64 @@ app.get("/api/shared-with-me", async (c) => {
     return c.json(notes.filter(Boolean));
 });
 
-// Resolve share token link — JSON for SPA, redirect for direct browser hits
-app.get("/api/shared/:token", async (c) => {
+// OG image for shared notes
+app.get("/api/shared/:token/og-image.png", async (c) => {
     const authStub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
     const res = await authStub.fetch(new Request(`https://do/internal/shares/by-token?token=${encodeURIComponent(c.req.param("token"))}`));
+    if (!res.ok) return c.text("Not found", 404);
+    const { noteId, ownerId } = await res.json() as any;
+
+    const ownerStub = c.env.USER_NOTES_DO.get(c.env.USER_NOTES_DO.idFromName(ownerId));
+    const noteRes = await ownerStub.fetch(new Request(`https://do/notes/${noteId}`));
+    if (!noteRes.ok) return c.text("Not found", 404);
+    const note = await noteRes.json() as any;
+
+    const png = await generateOgImage(note.title || "Untitled", note.content || "");
+    return c.body(png as any, 200, {
+        "Content-Type": "image/png",
+        "Cache-Control": "public, max-age=3600",
+    });
+});
+
+// Resolve share token link — JSON for SPA, HTML with OG tags for crawlers
+app.get("/api/shared/:token", async (c) => {
+    const token = c.req.param("token");
+    const authStub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
+    const res = await authStub.fetch(new Request(`https://do/internal/shares/by-token?token=${encodeURIComponent(token)}`));
     if (!res.ok) return c.text("Invalid or expired share link", 404);
-    const { noteId } = await res.json() as any;
+    const { noteId, ownerId } = await res.json() as any;
+
     const accept = c.req.header("accept") || "";
     if (accept.includes("application/json")) {
-        return c.json({ noteId, token: c.req.param("token") });
+        return c.json({ noteId, token });
     }
-    return c.redirect(`/note/${noteId}?share=${c.req.param("token")}`);
+
+    // Fetch note metadata for OG tags
+    const ownerStub = c.env.USER_NOTES_DO.get(c.env.USER_NOTES_DO.idFromName(ownerId));
+    const noteRes = await ownerStub.fetch(new Request(`https://do/notes/${noteId}/meta`));
+    const title = noteRes.ok ? ((await noteRes.json()) as any).title || "Untitled" : "Shared Note";
+
+    const origin = new URL(c.req.url).origin;
+    const ogImageUrl = `${origin}/api/shared/${token}/og-image.png`;
+    const redirectUrl = `/note/${noteId}?share=${token}`;
+
+    return c.html(`<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta property="og:title" content="${escapeAttr(title)}">
+<meta property="og:description" content="Shared via Notty">
+<meta property="og:image" content="${ogImageUrl}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeAttr(title)}">
+<meta name="twitter:image" content="${ogImageUrl}">
+<meta http-equiv="refresh" content="0;url=${redirectUrl}">
+<title>${escapeAttr(title)} — Notty</title>
+</head><body>
+<p>Redirecting…</p>
+<script>location.replace(${JSON.stringify(redirectUrl)})</script>
+</body></html>`);
 });
 
 // --- Profile API ---

--- a/src/server/og-image.ts
+++ b/src/server/og-image.ts
@@ -1,0 +1,166 @@
+import satori from "satori";
+import { Resvg, initWasm } from "@resvg/resvg-wasm";
+// @ts-expect-error wasm import
+import resvgWasm from "@resvg/resvg-wasm/index_bg.wasm";
+
+let wasmReady = false;
+
+async function ensureWasm() {
+    if (wasmReady) return;
+    await initWasm(resvgWasm);
+    wasmReady = true;
+}
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+function extractPlainText(content: string, maxLen = 280): string {
+    try {
+        const doc = typeof content === "string" ? JSON.parse(content) : content;
+        if (!doc?.content) return "";
+        const parts: string[] = [];
+        function walk(nodes: any[]) {
+            for (const node of nodes) {
+                if (node.type === "text" && node.text) parts.push(node.text);
+                if (node.content) walk(node.content);
+            }
+        }
+        walk(doc.content.slice(1)); // skip first node (title heading)
+        const text = parts.join(" ").replace(/\s+/g, " ").trim();
+        return text.length > maxLen ? text.slice(0, maxLen) + "…" : text;
+    } catch {
+        return "";
+    }
+}
+
+async function loadFont(): Promise<ArrayBuffer> {
+    const res = await fetch(
+        "https://fonts.googleapis.com/css2?family=DM+Sans:wght@500;700&display=swap"
+    );
+    const css = await res.text();
+    const urls = [...css.matchAll(/url\(([^)]+)\)/g)].map((m) => m[1]);
+    // Fetch the first woff2 font file
+    const fontRes = await fetch(urls[0]);
+    return fontRes.arrayBuffer();
+}
+
+let fontCache: ArrayBuffer | null = null;
+
+export async function generateOgImage(
+    title: string,
+    content: string
+): Promise<ArrayBuffer> {
+    await ensureWasm();
+    if (!fontCache) fontCache = await loadFont();
+
+    const excerpt = extractPlainText(content);
+
+    const svg = await satori(
+        ({
+            type: "div",
+            props: {
+                style: {
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    padding: "60px 80px",
+                    background: "linear-gradient(145deg, #FAF8F5 0%, #F0ECE4 100%)",
+                    fontFamily: "DM Sans",
+                },
+                children: [
+                    {
+                        type: "div",
+                        props: {
+                            style: {
+                                display: "flex",
+                                alignItems: "center",
+                                marginBottom: "32px",
+                                gap: "12px",
+                            },
+                            children: [
+                                {
+                                    type: "div",
+                                    props: {
+                                        style: {
+                                            width: "36px",
+                                            height: "36px",
+                                            borderRadius: "8px",
+                                            background: "#2C2416",
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "center",
+                                            color: "#FAF8F5",
+                                            fontSize: "18px",
+                                            fontWeight: 700,
+                                        },
+                                        children: "N",
+                                    },
+                                },
+                                {
+                                    type: "div",
+                                    props: {
+                                        style: {
+                                            fontSize: "20px",
+                                            color: "#8C8474",
+                                            fontWeight: 500,
+                                        },
+                                        children: "Shared via Notty",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        type: "div",
+                        props: {
+                            style: {
+                                fontSize: "52px",
+                                fontWeight: 700,
+                                color: "#2C2416",
+                                lineHeight: 1.2,
+                                marginBottom: "24px",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                            },
+                            children: title || "Untitled",
+                        },
+                    },
+                    excerpt
+                        ? {
+                              type: "div",
+                              props: {
+                                  style: {
+                                      fontSize: "24px",
+                                      color: "#8C8474",
+                                      lineHeight: 1.5,
+                                      overflow: "hidden",
+                                      textOverflow: "ellipsis",
+                                  },
+                                  children: excerpt,
+                              },
+                          }
+                        : {
+                              type: "div",
+                              props: { style: { display: "none" }, children: "" },
+                          },
+                ],
+            },
+        }) as any,
+        {
+            width: WIDTH,
+            height: HEIGHT,
+            fonts: [
+                { name: "DM Sans", data: fontCache, weight: 500, style: "normal" as const },
+                { name: "DM Sans", data: fontCache, weight: 700, style: "normal" as const },
+            ],
+        }
+    );
+
+    const resvg = new Resvg(svg, {
+        fitTo: { mode: "width" as const, value: WIDTH },
+    });
+    const png = resvg.render();
+    return png.asPng().buffer as ArrayBuffer;
+}

--- a/src/server/public-page.ts
+++ b/src/server/public-page.ts
@@ -80,6 +80,26 @@ function renderNode(node: any): string {
     }
 }
 
+function extractExcerpt(content: string, skipFirst = false, maxLen = 160): string {
+    try {
+        const doc = typeof content === "string" ? JSON.parse(content) : content;
+        if (!doc?.content) return "";
+        const nodes = skipFirst ? doc.content.slice(1) : doc.content;
+        const parts: string[] = [];
+        function walk(ns: any[]) {
+            for (const n of ns) {
+                if (n.type === "text" && n.text) parts.push(n.text);
+                if (n.content) walk(n.content);
+            }
+        }
+        walk(nodes);
+        const text = parts.join(" ").replace(/\s+/g, " ").trim();
+        return escapeHtml(text.length > maxLen ? text.slice(0, maxLen) + "…" : text);
+    } catch {
+        return "";
+    }
+}
+
 const BODY_FONTS: Record<string, string> = {
     sans: '"DM Sans", system-ui, sans-serif',
     serif: '"Source Serif 4", Georgia, "Times New Roman", serif',
@@ -196,12 +216,21 @@ export function renderPublicNote(profile: any, note: any, baseUrl: string): stri
     const font = profile.font || "serif";
     const colorMode = profile.color_mode || "light";
 
+    const excerpt = extractExcerpt(note.content, true);
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${noteTitle} — ${pageTitle}</title>
+    <meta name="description" content="${excerpt}">
+    <meta property="og:title" content="${noteTitle}">
+    <meta property="og:description" content="${excerpt}">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="${noteTitle}">
+    <meta name="twitter:description" content="${excerpt}">
     <link rel="alternate" type="application/rss+xml" title="${pageTitle}" href="${baseUrl}/rss">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Generates dynamic 1200×630 PNG OG images for shared note links using satori + resvg-wasm
- Shared link route (`/api/shared/:token`) now serves HTML with `og:title`, `og:image`, `twitter:card` meta tags for crawlers, with instant JS redirect for real users
- Added OG meta tags to public subdomain note pages

## Test plan
- [ ] Share a note link and paste it in Slack/Discord/Twitter — verify rich preview shows title + excerpt
- [ ] Verify `/api/shared/:token/og-image.png` returns a valid PNG
- [ ] Verify SPA still works (JSON requests unaffected)
- [ ] Verify public pages at `username.notty.page/noteId` include OG tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)