### PR TITLE
fix: notes losing folder on edit

### DIFF
--- a/src/client/pages/note.tsx
+++ b/src/client/pages/note.tsx
@@ -131,8 +131,8 @@ export function NotePage() {
     const { user, loading: authLoading } = useAuth();
     const shareToken = searchParams.get("share") || undefined;
 
-    // Folder attachment is deferred — the editor's first save will include it
-    const folderId = searchParams.get("folder");
+    // Only pass folder_id on first save (new note) — undefined means "don't change"
+    const folderId = searchParams.get("folder") ?? undefined;
 
     const [showControls, setShowControls] = useState(true);
     const [showShare, setShowShare] = useState(false);


### PR DESCRIPTION
## Summary
- When editing a note inside a folder, the note's `folder_id` was cleared because `searchParams.get("folder")` returns `null` when no `?folder=` param exists in the URL, and `null` was sent to the server as an explicit "remove from folder"
- Changed to `?? undefined` so the save pipeline skips the `folder_id` update entirely, preserving the note's existing folder assignment

## Test plan
- [ ] Create a note inside a folder
- [ ] Open and edit the note
- [ ] Verify the note stays in its folder after saving
- [ ] Verify creating a new note from a folder view still assigns it to that folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)