### PR TITLE
fix: prevent content duplication on shared links

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -212,8 +212,11 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
     useEffect(() => {
         let cancelled = false;
 
+        const persistenceReady = provider.persistence
+            ? provider.persistence.whenSynced
+            : Promise.resolve();
         Promise.race([
-            provider.persistence.whenSynced,
+            persistenceReady,
             new Promise((r) => setTimeout(r, 150)),
         ]).then(() => {
             if (cancelled) return;
@@ -221,6 +224,13 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
             const hasYjsContent = ydoc.getXmlFragment("default").length > 1;
 
             if (hasYjsContent) {
+                setReady(true);
+                return;
+            }
+
+            // Shared notes get content from WebSocket sync — skip HTTP bootstrap
+            // to avoid duplicate content (HTTP + Yjs sync create independent ops)
+            if (shareToken) {
                 setReady(true);
                 return;
             }

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -11,7 +11,7 @@ const MSG_AWARENESS = 1;
 export class NottyProvider {
     doc: Y.Doc;
     awareness: awarenessProtocol.Awareness;
-    persistence: IndexeddbPersistence;
+    persistence: IndexeddbPersistence | null;
     private ws: WebSocket | null = null;
     private connected = false;
     private destroyed = false;
@@ -32,8 +32,10 @@ export class NottyProvider {
         this.offlineOnly = options?.connect === false;
         this.shareToken = options?.shareToken;
 
-        // Offline persistence — loads cached doc from IndexedDB immediately
-        this.persistence = new IndexeddbPersistence(`notty-${noteId}`, doc);
+        // Offline persistence — skip for shared notes (no offline use, avoids stale duplicates)
+        this.persistence = options?.shareToken
+            ? null
+            : new IndexeddbPersistence(`notty-${noteId}`, doc);
 
         this.doc.on("update", (update: Uint8Array, origin: any) => {
             if (origin === this) return;
@@ -159,7 +161,7 @@ export class NottyProvider {
     destroy() {
         this.destroyed = true;
         this.awareness.destroy();
-        this.persistence.destroy();
+        this.persistence?.destroy();
         this.ws?.close();
         this.ws = null;
     }


### PR DESCRIPTION
## Summary
- Skip HTTP content bootstrap for shared notes — the Yjs WebSocket sync is the sole source of truth, preventing duplicate content from independent Yjs ops merging
- Skip IndexedDB persistence for shared notes to avoid caching stale/duplicated state

## Test plan
- [ ] Open a shared link as a new user — content should load once (no duplication)
- [ ] Open the same shared link again — still no duplication
- [ ] Owner's notes still bootstrap correctly from HTTP when Yjs doc is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)