### PR TITLE
feat: add sign out to command palette

### DIFF
--- a/src/components/auth-section.tsx
+++ b/src/components/auth-section.tsx
@@ -83,7 +83,7 @@ export function AuthSection() {
                     </div>
                     <button
                         onClick={signOut}
-                        className="text-[10px] px-2 py-1 rounded-md text-[var(--color-ink-muted)] hover:bg-[var(--color-sidebar-active)] transition-colors shrink-0"
+                        className="text-[11px] px-2.5 py-1 rounded-lg text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-sidebar-active)] transition-colors shrink-0"
                     >
                         Sign out
                     </button>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { useNotes } from "@/context/notes-context";
 import { useFolders } from "@/context/folders-context";
+import { useAuth } from "@/context/auth-context";
 import { useHotkeys, isMac } from "@/lib/hotkeys";
 import { extractPreview } from "./note-card";
 import { toggleDarkMode } from "@/lib/dark-mode";
@@ -26,6 +27,8 @@ export function CommandPalette() {
     const navigate = useNavigate();
     const { notes } = useNotes();
     const { folders, selectFolder } = useFolders();
+    const { user, signOut } = useAuth();
+    const isAnonymous = user?.isAnonymous || !user?.email;
 
     const close = useCallback(() => { setOpen(false); setQuery(""); setSelected(0); }, []);
 
@@ -70,6 +73,10 @@ export function CommandPalette() {
             },
         });
 
+        if (!isAnonymous) {
+            items.push({ id: "sign-out", title: "Sign Out", section: "Actions", action: () => { signOut(); close(); } });
+        }
+
         // Folders
         items.push({ id: "folder-all", title: "All Notes", section: "Folders", action: () => { selectFolder(null); navigate("/"); close(); } });
         for (const f of folders) {
@@ -94,7 +101,7 @@ export function CommandPalette() {
         }
 
         return items;
-    }, [notes, folders, createNewNote, toggleDark, navigate, selectFolder, close]);
+    }, [notes, folders, createNewNote, toggleDark, navigate, selectFolder, close, isAnonymous, signOut]);
 
     const filtered = useMemo(() => {
         if (!query.trim()) return commands;


### PR DESCRIPTION
## Summary
- Added "Sign Out" command to the command palette (Cmd+K), accessible from any page
- Made the existing sidebar sign out button slightly more visible

## Test plan
- [ ] Open the app on web, sign in, press Cmd+K, type "sign out" — should appear and work
- [ ] Verify sidebar sign out button still works with updated styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)