### PR TITLE
feat: Tauri quick notes + desktop auth

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1128,6 +1128,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1268,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -1939,6 +1967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2189,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-shell",
  "tauri-plugin-store",
  "tokio",
@@ -3044,6 +3079,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +3856,21 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5413,6 +5476,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "5"
 tauri-plugin-store = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-global-shortcut = "2"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,22 @@
+{
+    "identifier": "default",
+    "description": "Default capabilities for all windows",
+    "windows": ["*"],
+    "permissions": [
+        "core:default",
+        "core:window:default",
+        "core:window:allow-hide",
+        "core:window:allow-show",
+        "core:window:allow-set-focus",
+        "core:window:allow-close",
+        "core:window:allow-start-dragging",
+        "core:webview:default",
+        "core:webview:allow-create-webview-window",
+        "global-shortcut:allow-register",
+        "global-shortcut:allow-unregister",
+        "global-shortcut:allow-is-registered",
+        "shell:allow-open",
+        "store:default",
+        "deep-link:default"
+    ]
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -53,6 +53,11 @@ impl Database {
         let _ = conn.execute_batch("ALTER TABLE notes ADD COLUMN sync_mode TEXT NOT NULL DEFAULT 'cloud'");
         let _ = conn.execute_batch("ALTER TABLE folders ADD COLUMN description TEXT NOT NULL DEFAULT ''");
         let _ = conn.execute_batch("ALTER TABLE notes ADD COLUMN deleted_at INTEGER");
+        // Ensure the __quick_notes__ folder exists
+        let _ = conn.execute(
+            "INSERT OR IGNORE INTO folders (id, name, color, description, sort_order) VALUES ('__quick_notes__', 'Quick Notes', '#F59E0B', 'Notes created via quick capture', -1)",
+            [],
+        );
         Ok(Database(Mutex::new(conn)))
     }
 }
@@ -252,6 +257,30 @@ pub fn save_folder(
     )
     .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_quick_notes(db: tauri::State<Database>) -> Result<Vec<Note>, String> {
+    let conn = db.0.lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare("SELECT id, title, content, folder_id, sync_mode, created_at, updated_at FROM notes WHERE folder_id = '__quick_notes__' AND deleted_at IS NULL ORDER BY updated_at DESC")
+        .map_err(|e| e.to_string())?;
+    let notes = stmt
+        .query_map([], |row| {
+            Ok(Note {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                content: row.get(2)?,
+                folder_id: row.get(3)?,
+                sync_mode: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|n| n.ok())
+        .collect();
+    Ok(notes)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,13 +3,31 @@
 mod db;
 mod sync;
 
-use tauri::{Manager, Listener, Emitter};
+use tauri::{Manager, Listener, Emitter, WebviewWindowBuilder};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
+
+#[tauri::command]
+fn open_note_in_main(app: tauri::AppHandle, note_id: String) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.show();
+        let _ = win.set_focus();
+        // Use history.pushState + popstate to trigger React Router navigation
+        win.eval(&format!(
+            "history.pushState(null, '', '/note/{}'); window.dispatchEvent(new PopStateEvent('popstate'));",
+            note_id
+        )).map_err(|e| e.to_string())?;
+        Ok(())
+    } else {
+        Err("Main window not found".into())
+    }
+}
 
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup(|app| {
             let app_dir = app.path().app_data_dir().expect("failed to get app dir");
             std::fs::create_dir_all(&app_dir).ok();
@@ -24,13 +42,44 @@ fn main() {
             app.manage(sync::SyncDir(sync_dir));
 
             // Listen for deep link events (notty://auth?token=...)
+            // Payload is a JSON array of URLs: ["notty://auth?token=xxx"]
             let handle = app.handle().clone();
             app.listen("deep-link://new-url", move |event| {
-                if let Some(payload) = event.payload().strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
-                    // Emit to frontend so JS can handle the token exchange
-                    let _ = handle.emit("auth-deep-link", payload);
+                if let Ok(urls) = serde_json::from_str::<Vec<String>>(event.payload()) {
+                    if let Some(url) = urls.first() {
+                        let _ = handle.emit("auth-deep-link", url.as_str());
+                    }
                 }
             });
+
+            // Global shortcut: Cmd+Option+N → toggle quick note window
+            let handle = app.handle().clone();
+            let shortcut: Shortcut = "CmdOrCtrl+Alt+N".parse().expect("invalid shortcut");
+            app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+                if event.state != ShortcutState::Pressed { return; }
+
+                if let Some(win) = handle.get_webview_window("quick-note") {
+                    if win.is_visible().unwrap_or(false) {
+                        let _ = win.hide();
+                    } else {
+                        let _ = win.show();
+                        let _ = win.set_focus();
+                    }
+                } else {
+                    let _ = WebviewWindowBuilder::new(
+                        &handle,
+                        "quick-note",
+                        tauri::WebviewUrl::App("/quick-note".into()),
+                    )
+                    .title("Quick Note")
+                    .inner_size(420.0, 340.0)
+                    .resizable(true)
+                    .always_on_top(true)
+                    .decorations(false)
+                    .center()
+                    .build();
+                }
+            })?;
 
             Ok(())
         })
@@ -47,6 +96,8 @@ fn main() {
             db::get_folders,
             db::save_folder,
             db::delete_folder,
+            db::get_quick_notes,
+            open_note_in_main,
             sync::sync_to_markdown,
             sync::sync_from_markdown,
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
     },
     "bundle": {
         "active": true,
-        "targets": "all",
+        "targets": ["app", "dmg"],
         "icon": ["icons/icon.png"]
     }
 }

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -13,6 +13,8 @@ import { AuthPasskeyPage } from "./pages/auth-passkey";
 import { SharedResolvePage } from "./pages/shared-resolve";
 import { PublicSettingsPage } from "./pages/public-settings";
 import { TrashPage } from "./pages/trash";
+import { lazy, Suspense } from "react";
+const QuickNotePage = lazy(() => import("./pages/quick-note").then(m => ({ default: m.QuickNotePage })));
 import { Toaster } from "sonner";
 import "@/styles/globals.css";
 
@@ -49,6 +51,7 @@ getAdapter().then((adapter) => {
                                         <Route path="/auth/passkey" element={<AuthPasskeyPage />} />
                                         <Route path="/shared/:token" element={<SharedResolvePage />} />
                                         <Route path="/settings/public" element={<PublicSettingsPage />} />
+                                        <Route path="/quick-note" element={<Suspense><QuickNotePage /></Suspense>} />
                                     </Routes>
                                 </MediaProvider>
                             </FoldersProvider>

--- a/src/client/pages/quick-note.tsx
+++ b/src/client/pages/quick-note.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Editor } from "@/components/editor";
+import { useNotes, type Note } from "@/context/notes-context";
+import { useAuth } from "@/context/auth-context";
+import { ChevronLeft, ChevronRight, Plus, X, ExternalLink } from "lucide-react";
+
+const QUICK_FOLDER = "__quick_notes__";
+
+async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return invoke(cmd, args);
+}
+
+async function hideWindow() {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    getCurrentWindow().hide();
+}
+
+
+export function QuickNotePage() {
+    // Sync theme from localStorage (separate webview may not inherit the class)
+    useEffect(() => {
+        const theme = localStorage.getItem("theme");
+        if (theme === "dark") {
+            document.documentElement.classList.add("dark");
+        } else {
+            document.documentElement.classList.remove("dark");
+        }
+    }, []);
+
+    const { createNote, saveNote } = useNotes();
+    const { user } = useAuth();
+    const [quickNotes, setQuickNotes] = useState<Note[]>([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [loaded, setLoaded] = useState(false);
+    const quickNotesRef = useRef(quickNotes);
+    quickNotesRef.current = quickNotes;
+    const currentIndexRef = useRef(currentIndex);
+    currentIndexRef.current = currentIndex;
+
+    const loadQuickNotes = useCallback(async () => {
+        const notes: Note[] = await tauriInvoke("get_quick_notes");
+        setQuickNotes(notes);
+        return notes;
+    }, []);
+
+    const addNewNote = useCallback(async () => {
+        const id = crypto.randomUUID();
+        createNote(id, QUICK_FOLDER);
+        const newNote: Note = {
+            id,
+            title: "Untitled",
+            content: "",
+            folder_id: QUICK_FOLDER,
+            created_at: Date.now() / 1000,
+            updated_at: Date.now() / 1000,
+        };
+        setQuickNotes((prev) => [newNote, ...prev]);
+        setCurrentIndex(0);
+    }, [createNote]);
+
+    useEffect(() => {
+        loadQuickNotes().then((notes) => {
+            if (notes.length === 0) addNewNote();
+            setLoaded(true);
+        });
+    }, []);
+
+    // Reload quick notes from DB when window regains focus (picks up saves from cycling)
+    useEffect(() => {
+        const onFocus = () => loadQuickNotes();
+        window.addEventListener("focus", onFocus);
+        return () => window.removeEventListener("focus", onFocus);
+    }, [loadQuickNotes]);
+
+    const prev = useCallback(() => {
+        setCurrentIndex((i) => (i > 0 ? i - 1 : quickNotesRef.current.length - 1));
+    }, []);
+
+    const next = useCallback(() => {
+        setCurrentIndex((i) => (i < quickNotesRef.current.length - 1 ? i + 1 : 0));
+    }, []);
+
+    const openInMain = useCallback(async () => {
+        const note = quickNotesRef.current[currentIndexRef.current];
+        if (!note) return;
+        await tauriInvoke("open_note_in_main", { noteId: note.id });
+        hideWindow();
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") { e.preventDefault(); hideWindow(); }
+            if (e.metaKey && e.key === "[") { e.preventDefault(); prev(); }
+            if (e.metaKey && e.key === "]") { e.preventDefault(); next(); }
+            if (e.metaKey && e.key === "n") { e.preventDefault(); addNewNote(); }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [prev, next, addNewNote]);
+
+    if (!loaded || !user) {
+        return <div className="h-screen bg-[var(--color-paper)] flex items-center justify-center text-sm text-[var(--color-ink-muted)]">Loading...</div>;
+    }
+
+    const currentNote = quickNotes[currentIndex];
+
+    return (
+        <div className="h-screen flex flex-col bg-[var(--color-paper)] rounded-xl overflow-hidden">
+            {/* Draggable title bar */}
+            <div
+                className="flex items-center justify-between px-3 py-2 border-b border-[var(--color-border-warm)] select-none shrink-0"
+                data-tauri-drag-region
+                style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+            >
+                <span className="text-xs text-[var(--color-ink-muted)] font-serif italic">
+                    quick note
+                </span>
+
+                <div className="flex items-center gap-1" style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
+                    {quickNotes.length > 1 && (
+                        <>
+                            <button onClick={prev} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="Previous (Cmd+[)">
+                                <ChevronLeft size={14} className="text-[var(--color-ink-muted)]" />
+                            </button>
+                            <span className="text-[10px] text-[var(--color-ink-muted)] tabular-nums min-w-[2rem] text-center">
+                                {currentIndex + 1} / {quickNotes.length}
+                            </span>
+                            <button onClick={next} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="Next (Cmd+])">
+                                <ChevronRight size={14} className="text-[var(--color-ink-muted)]" />
+                            </button>
+                        </>
+                    )}
+                    <button onClick={addNewNote} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="New quick note (Cmd+N)">
+                        <Plus size={14} className="text-[var(--color-ink-muted)]" />
+                    </button>
+                    <button onClick={openInMain} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="Open in main window">
+                        <ExternalLink size={14} className="text-[var(--color-ink-muted)]" />
+                    </button>
+                    <button onClick={hideWindow} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="Close (Esc)">
+                        <X size={14} className="text-[var(--color-ink-muted)]" />
+                    </button>
+                </div>
+            </div>
+
+            {/* Editor */}
+            <div className="flex-1 overflow-auto">
+                {currentNote && (
+                    <Editor
+                        key={currentNote.id}
+                        noteId={currentNote.id}
+                        folderId={QUICK_FOLDER}
+                        compact
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -79,7 +79,7 @@ const FONT_STYLES: Record<FontChoice, React.CSSProperties> = {
     mono: { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" },
 };
 
-export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGuardRef }: { noteId: string; shareToken?: string; readOnly?: boolean; folderId?: string | null; saveGuardRef?: React.MutableRefObject<boolean> }) {
+export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGuardRef, compact = false }: { noteId: string; shareToken?: string; readOnly?: boolean; folderId?: string | null; saveGuardRef?: React.MutableRefObject<boolean>; compact?: boolean }) {
     const { saveNote } = useNotes();
     const adapter = useAdapter();
     const { user } = useAuth();
@@ -215,10 +215,12 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         const persistenceReady = provider.persistence
             ? provider.persistence.whenSynced
             : Promise.resolve();
-        Promise.race([
-            persistenceReady,
-            new Promise((r) => setTimeout(r, 150)),
-        ]).then(() => {
+        // In compact mode (quick notes), always wait for IndexedDB — no timeout race.
+        // In normal mode, race with 150ms to avoid blocking on slow persistence.
+        const waitForPersistence = compact
+            ? persistenceReady
+            : Promise.race([persistenceReady, new Promise((r) => setTimeout(r, 150))]);
+        waitForPersistence.then(() => {
             if (cancelled) return;
 
             const hasYjsContent = ydoc.getXmlFragment("default").length > 1;
@@ -277,8 +279,17 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
             // still save — catches the case where escape fires before first debounce
             if (editorRef.current) saveNowRef.current(editorRef.current);
         }
-        provider.destroy();
-        ydoc.destroy();
+        // Wait for IndexedDB to finish writing before destroying the doc,
+        // so cycling back to this note loads the correct content.
+        if (provider.persistence) {
+            provider.persistence.whenSynced.then(() => {
+                provider.destroy();
+                ydoc.destroy();
+            });
+        } else {
+            provider.destroy();
+            ydoc.destroy();
+        }
     }, [provider, ydoc, debouncedSave]);
 
     const collabExtensions = useMemo(() => [
@@ -317,7 +328,7 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
     }
 
     return (
-        <div className="relative min-h-[500px]" data-font={font}>
+        <div className={`relative ${compact ? "min-h-[200px]" : "min-h-[500px]"}`} data-font={font}>
             {/* Collaborator avatars */}
             {collaborators.length > 0 && (
                 <div className="absolute top-5 right-6 z-10 flex items-center -space-x-2">
@@ -340,8 +351,8 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                 </div>
             )}
 
-            {/* Toolbar — font + lines toggle (hidden for read-only) */}
-            {!readOnly && <div className="absolute top-5 left-6 z-10 flex items-center gap-1.5">
+            {/* Toolbar — font + lines toggle (hidden for read-only and compact) */}
+            {!readOnly && !compact && <div className="absolute top-5 left-6 z-10 flex items-center gap-1.5">
                 <button
                     onClick={cycleFont}
                     className="text-xs px-2.5 py-1 rounded-lg border border-[var(--color-border-warm)] bg-[var(--color-paper)] text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors"
@@ -368,13 +379,13 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                 <EditorContent
                     extensions={collabExtensions}
                     editable={!readOnly}
-                    className={`px-10 py-14 sm:px-16 sm:py-20 ${showLines ? "editor-ruled-bg" : ""} ${readOnly ? "cursor-default" : ""}`}
+                    className={`${compact ? "px-4 py-3" : "px-10 py-14 sm:px-16 sm:py-20"} ${showLines ? "editor-ruled-bg" : ""} ${readOnly ? "cursor-default" : ""}`}
                     editorProps={{
                         handleDOMEvents: {
                             keydown: (_view, event) => readOnly ? false : handleCommandNavigation(event),
                         },
                         attributes: {
-                            class: `focus:outline-none max-w-full min-h-[400px] ${readOnly ? "select-text" : ""}`,
+                            class: `focus:outline-none max-w-full ${compact ? "min-h-[180px]" : "min-h-[400px]"} ${readOnly ? "select-text" : ""}`,
                         },
                     }}
                     onUpdate={({ editor }) => {
@@ -438,8 +449,8 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                 </EditorContent>
             </EditorRoot>
 
-            {/* Status bar — bottom */}
-            {!readOnly && !shareToken && (
+            {/* Status bar — bottom (hidden in compact mode) */}
+            {!readOnly && !shareToken && !compact && (
                 <div className="absolute bottom-4 left-6 right-6 z-10 flex items-center justify-between pointer-events-none">
                     <span
                         className="group pointer-events-auto text-[10px] tracking-wide text-[var(--color-ink-muted)]/40 hover:text-[var(--color-ink-muted)] transition-colors cursor-default select-none"

--- a/src/context/notes-context.tsx
+++ b/src/context/notes-context.tsx
@@ -15,7 +15,7 @@ type NotesContextType = {
     notes: Note[];
     trash: Note[];
     loading: boolean;
-    createNote: (id: string) => Promise<Note>;
+    createNote: (id: string, folderId?: string | null) => Promise<Note>;
     deleteNote: (id: string) => Promise<void>;
     restoreNote: (id: string) => Promise<void>;
     permanentlyDeleteNote: (id: string) => Promise<void>;
@@ -189,11 +189,11 @@ export function NotesProvider({ children }: { children: ReactNode }) {
         adapter.saveNote(id, title, content, folderId);
     }, [adapter]);
 
-    const createNote = useCallback(async (id: string): Promise<Note> => {
-        const note: Note = { id, title: "Untitled", content: "", created_at: Date.now(), updated_at: Date.now() };
+    const createNote = useCallback(async (id: string, folderId?: string | null): Promise<Note> => {
+        const note: Note = { id, title: "Untitled", content: "", folder_id: folderId, created_at: Date.now(), updated_at: Date.now() };
         localEditsRef.current.set(id, note);
         setNotes((prev) => [note, ...prev]);
-        adapter.saveNote(id, "Untitled", "");
+        adapter.saveNote(id, "Untitled", "", folderId);
         return note;
     }, [adapter]);
 

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -2,6 +2,19 @@ import { createAuthClient } from "better-auth/react";
 import { anonymousClient } from "better-auth/client/plugins";
 import { passkeyClient } from "@better-auth/passkey/client";
 
+// Better Auth rejects non-http origins (like tauri://localhost), so we must provide an explicit baseURL
+const needsExplicitBase = typeof window !== "undefined" &&
+  window.location?.protocol !== "http:" &&
+  window.location?.protocol !== "https:";
+
 export const authClient = createAuthClient({
+  baseURL: needsExplicitBase ? "https://notty.page" : undefined!,
   plugins: [anonymousClient(), passkeyClient()],
 });
+
+export function createDesktopAuthClient(baseURL: string) {
+  return createAuthClient({
+    baseURL,
+    plugins: [anonymousClient(), passkeyClient()],
+  });
+}

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -11,8 +11,14 @@ export async function handleDeepLinkToken(url: string) {
     if (!token) return;
     const { getDesktopSettings } = await import("@/lib/desktop-settings");
     const settings = await getDesktopSettings();
-    await fetch(`${settings.cloudUrl}/api/auth/exchange-token?token=${token}`, {
-        credentials: "include",
-    });
+    const res = await fetch(`${settings.cloudUrl}/api/auth/exchange-token?token=${token}`);
+    if (!res.ok) return;
+    const data = await res.json() as { sessionToken?: string };
+    if (data.sessionToken) {
+        const { load } = await import("@tauri-apps/plugin-store");
+        const store = await load("settings.json");
+        await store.set("sessionToken", data.sessionToken);
+        await store.save();
+    }
     window.location.reload();
 }

--- a/src/lib/desktop-adapter.ts
+++ b/src/lib/desktop-adapter.ts
@@ -1,7 +1,7 @@
 import type { NottyAdapter, Note, NoteVersion, NoteBranch, NoteTree, User, Folder, Share, SharedNote, Profile, MediaItem } from "./adapter";
 import type * as Y from "yjs";
 import { NottyProvider } from "./yjs-provider";
-import { authClient } from "./auth-client";
+import { authClient, createDesktopAuthClient } from "./auth-client";
 import { getDesktopSettings } from "./desktop-settings";
 
 async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
@@ -17,6 +17,23 @@ function syncMarkdown() {
 // Never blocks local operations — cloud sync is fire-and-forget.
 let cloudUrlCache: string | null | undefined = undefined; // undefined = not checked yet
 let cloudCheckPromise: Promise<string | null> | null = null;
+let cloudAuthClient: ReturnType<typeof createDesktopAuthClient> | null = null;
+let sessionTokenCache: string | null = null;
+
+function getCloudAuth() {
+    return cloudAuthClient || authClient;
+}
+
+// Authenticated fetch to cloud — attaches session token via custom header
+// (Cookie is a forbidden header in browser fetch, so we use X-Session-Token
+// and the server converts it to a cookie before passing to Better Auth)
+function cloudFetch(url: string, init?: RequestInit): Promise<Response> {
+    const headers = new Headers(init?.headers);
+    if (sessionTokenCache) {
+        headers.set("X-Session-Token", sessionTokenCache);
+    }
+    return fetch(url, { ...init, headers });
+}
 
 async function detectCloud(): Promise<string | null> {
     if (cloudUrlCache !== undefined) return cloudUrlCache;
@@ -27,8 +44,13 @@ async function detectCloud(): Promise<string | null> {
             const settings = await getDesktopSettings();
             const url = settings.cloudUrl;
             if (!url) { cloudUrlCache = null; return null; }
-            const res = await fetch(`${url}/api/auth/get-session`, { signal: AbortSignal.timeout(2000) });
-            if (res.ok) { cloudUrlCache = url; return url; }
+            sessionTokenCache = settings.sessionToken;
+            const res = await cloudFetch(`${url}/api/auth/get-session`, { signal: AbortSignal.timeout(2000) });
+            if (res.ok) {
+                cloudUrlCache = url;
+                cloudAuthClient = createDesktopAuthClient(url);
+                return url;
+            }
         } catch {}
         cloudUrlCache = null;
         return null;
@@ -40,6 +62,8 @@ async function detectCloud(): Promise<string | null> {
 export function resetCloudDetection() {
     cloudUrlCache = undefined;
     cloudCheckPromise = null;
+    cloudAuthClient = null;
+    sessionTokenCache = null;
 }
 
 // Fire-and-forget cloud sync — never awaited, never blocks local ops
@@ -56,11 +80,14 @@ export class DesktopAdapter implements NottyAdapter {
     }
 
     async getSession(): Promise<User | null> {
-        const cloud = cloudUrlCache;
-        if (cloud) {
+        const cloud = await detectCloud();
+        if (cloud && sessionTokenCache) {
             try {
-                const session = await authClient.getSession();
-                if (session.data?.user) return session.data.user as User;
+                const res = await cloudFetch(`${cloud}/api/auth/get-session`);
+                if (res.ok) {
+                    const data = await res.json() as { user?: User };
+                    if (data.user) return data.user;
+                }
             } catch {}
         }
         return { id: "local", name: "Local User" };
@@ -70,7 +97,7 @@ export class DesktopAdapter implements NottyAdapter {
         const cloud = await detectCloud();
         if (cloud) {
             try {
-                const res = await authClient.signIn.anonymous();
+                const res = await getCloudAuth().signIn.anonymous();
                 if (res.data?.user) return res.data.user as User;
             } catch {}
         }
@@ -78,7 +105,7 @@ export class DesktopAdapter implements NottyAdapter {
     }
 
     async signOut(): Promise<void> {
-        try { await authClient.signOut(); } catch {}
+        try { await getCloudAuth().signOut(); } catch {}
     }
 
     async getNotes(): Promise<Note[]> {
@@ -88,7 +115,7 @@ export class DesktopAdapter implements NottyAdapter {
         const cloud = cloudUrlCache;
         if (cloud) {
             try {
-                const res = await fetch(`${cloud}/api/notes`, { signal: AbortSignal.timeout(3000) });
+                const res = await cloudFetch(`${cloud}/api/notes`, { signal: AbortSignal.timeout(3000) });
                 if (res.ok) {
                     const cloudNotes: Note[] = await res.json();
                     const merged = new Map<string, Note>();
@@ -115,7 +142,7 @@ export class DesktopAdapter implements NottyAdapter {
         const cloud = cloudUrlCache;
         if (cloud) {
             try {
-                const res = await fetch(`${cloud}/api/notes/${id}`, { signal: AbortSignal.timeout(2000) });
+                const res = await cloudFetch(`${cloud}/api/notes/${id}`, { signal: AbortSignal.timeout(2000) });
                 if (res.ok) return res.json();
             } catch {}
         }
@@ -130,7 +157,7 @@ export class DesktopAdapter implements NottyAdapter {
         cloudSync((cloud) => {
             const body: Record<string, any> = { id, title, content };
             if (folderId !== undefined) body.folder_id = folderId;
-            fetch(`${cloud}/api/notes`, {
+            cloudFetch(`${cloud}/api/notes`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(body),
@@ -142,7 +169,7 @@ export class DesktopAdapter implements NottyAdapter {
         await invoke("soft_delete_note", { id });
         syncMarkdown();
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/notes/${id}`, { method: "DELETE" }).catch(() => {});
+            cloudFetch(`${cloud}/api/notes/${id}`, { method: "DELETE" }).catch(() => {});
         });
     }
 
@@ -154,7 +181,7 @@ export class DesktopAdapter implements NottyAdapter {
         await invoke("restore_note", { id });
         syncMarkdown();
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/notes/${id}/restore`, { method: "POST" }).catch(() => {});
+            cloudFetch(`${cloud}/api/notes/${id}/restore`, { method: "POST" }).catch(() => {});
         });
         return invoke("get_note", { id });
     }
@@ -163,7 +190,7 @@ export class DesktopAdapter implements NottyAdapter {
         await invoke("delete_note", { id });
         syncMarkdown();
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/notes/${id}/permanent`, { method: "DELETE" }).catch(() => {});
+            cloudFetch(`${cloud}/api/notes/${id}/permanent`, { method: "DELETE" }).catch(() => {});
         });
     }
 
@@ -172,7 +199,7 @@ export class DesktopAdapter implements NottyAdapter {
         const cloud = cloudUrlCache;
         if (cloud) {
             try {
-                const res = await fetch(`${cloud}/api/folders`, { signal: AbortSignal.timeout(3000) });
+                const res = await cloudFetch(`${cloud}/api/folders`, { signal: AbortSignal.timeout(3000) });
                 if (res.ok) {
                     const cloudFolders: Folder[] = await res.json();
                     const merged = new Map<string, Folder>();
@@ -194,7 +221,7 @@ export class DesktopAdapter implements NottyAdapter {
     async saveFolder(folder: Partial<Folder> & { id: string; name: string }): Promise<void> {
         await invoke("save_folder", { id: folder.id, name: folder.name, color: folder.color, description: folder.description, sortOrder: folder.sort_order });
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/folders`, {
+            cloudFetch(`${cloud}/api/folders`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(folder),
@@ -205,14 +232,14 @@ export class DesktopAdapter implements NottyAdapter {
     async deleteFolder(id: string): Promise<void> {
         await invoke("delete_folder", { id });
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/folders/${id}`, { method: "DELETE" }).catch(() => {});
+            cloudFetch(`${cloud}/api/folders/${id}`, { method: "DELETE" }).catch(() => {});
         });
     }
 
     async moveNoteToFolder(noteId: string, folderId: string | null): Promise<void> {
         await invoke("move_note_to_folder", { id: noteId, folderId });
         cloudSync((cloud) => {
-            fetch(`${cloud}/api/notes/${noteId}/folder`, {
+            cloudFetch(`${cloud}/api/notes/${noteId}/folder`, {
                 method: "PUT",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ folder_id: folderId }),
@@ -227,7 +254,7 @@ export class DesktopAdapter implements NottyAdapter {
             cloudSync(async (cloud) => {
                 const note = await invoke<Note | null>("get_note", { id: noteId });
                 if (note) {
-                    fetch(`${cloud}/api/notes`, {
+                    cloudFetch(`${cloud}/api/notes`, {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({ id: note.id, title: note.title, content: note.content, folder_id: note.folder_id, sync_mode: mode }),

--- a/src/lib/desktop-settings.ts
+++ b/src/lib/desktop-settings.ts
@@ -1,9 +1,11 @@
 export type DesktopSettings = {
     cloudUrl: string;
+    sessionToken: string | null;
 };
 
 const DEFAULTS: DesktopSettings = {
-    cloudUrl: "",
+    cloudUrl: "https://notty.page",
+    sessionToken: null,
 };
 
 export async function getDesktopSettings(): Promise<DesktopSettings> {
@@ -11,7 +13,8 @@ export async function getDesktopSettings(): Promise<DesktopSettings> {
         const { load } = await import("@tauri-apps/plugin-store");
         const store = await load("settings.json");
         const cloudUrl = await store.get<string>("cloudUrl");
-        return { cloudUrl: cloudUrl || DEFAULTS.cloudUrl };
+        const sessionToken = await store.get<string>("sessionToken");
+        return { cloudUrl: cloudUrl || DEFAULTS.cloudUrl, sessionToken: sessionToken || null };
     } catch {
         return DEFAULTS;
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ app.use("*", cors({
     origin: (origin) => origin || "*",
     credentials: true,
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization", "X-Lock-Token"],
+    allowHeaders: ["Content-Type", "Authorization", "X-Lock-Token", "X-Session-Token"],
 }));
 
 // --- Subdomain detection for public pages ---
@@ -94,8 +94,15 @@ async function getSession(env: Env, request: Request) {
     const stub = env.AUTH_DO.get(env.AUTH_DO.idFromName("auth-singleton"));
     const url = new URL(request.url);
     const headers = new Headers();
-    const cookie = request.headers.get("Cookie");
-    if (cookie) headers.set("Cookie", cookie);
+    // Forward existing cookie, or inject from X-Session-Token header
+    const existingCookie = request.headers.get("Cookie");
+    const headerToken = request.headers.get("X-Session-Token");
+    if (existingCookie) {
+        headers.set("Cookie", existingCookie);
+    } else if (headerToken) {
+        // Use __Secure- prefix since the DO request URL is https://
+        headers.set("Cookie", `__Secure-better-auth.session_token=${headerToken}`);
+    }
     const res = await stub.fetch(new Request(`${url.origin}/api/auth/get-session`, { headers }));
     if (!res.ok) return null;
     const data: any = await res.json();
@@ -175,44 +182,64 @@ function simpleHmac(secret: string, data: string): string {
     return hash.toString(36);
 }
 
-// --- Auth routes — proxy to AuthDO ---
+// Get the session cookie value, checking both Cookie header and X-Session-Token (Tauri desktop)
+function getSessionCookie(request: Request): string | null {
+    const cookie = request.headers.get("Cookie") || "";
+    // Match both __Secure-better-auth.session_token (HTTPS) and better-auth.session_token (HTTP)
+    const match = cookie.match(/(?:__Secure-)?better-auth\.session_token=([^;]+)/);
+    if (match) return match[1]!;
+    return request.headers.get("X-Session-Token");
+}
+
+// --- Auth routes — proxy to AuthDO, with token exchange for Tauri desktop ---
 app.on(["GET", "POST"], "/api/auth/*", async (c) => {
+    const path = new URL(c.req.url).pathname;
+
+    // Tauri desktop: create a one-time token from an authenticated session
+    if (path === "/api/auth/create-token" && c.req.method === "POST") {
+        const session = await getSession(c.env, c.req.raw);
+        if (!session) return c.text("Unauthorized", 401);
+        const sessionToken = getSessionCookie(c.req.raw);
+        if (!sessionToken) return c.text("No session", 400);
+
+        const token = crypto.randomUUID();
+        const stub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
+        await stub.fetch(new Request("https://do/internal/tokens", {
+            method: "POST",
+            body: JSON.stringify({ token, sessionToken }),
+        }));
+        return c.json({ token });
+    }
+
+    // Tauri desktop: exchange a one-time token for a session token
+    if (path === "/api/auth/exchange-token" && c.req.method === "GET") {
+        const token = c.req.query("token");
+        if (!token) return c.text("Missing token", 400);
+
+        const stub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
+        const res = await stub.fetch(new Request(`https://do/internal/tokens?token=${token}`));
+        if (!res.ok) return c.text("Invalid or expired token", 401);
+        const { sessionToken } = await res.json() as { sessionToken: string };
+
+        return new Response(JSON.stringify({ ok: true, sessionToken }), {
+            headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": c.req.header("Origin") || "*",
+                "Access-Control-Allow-Credentials": "true",
+                "Set-Cookie": `__Secure-better-auth.session_token=${sessionToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=604800`,
+            },
+        });
+    }
+
+    // Default: proxy to AuthDO (Better Auth)
     const stub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
+    const headerToken = c.req.header("X-Session-Token");
+    if (headerToken && !c.req.header("Cookie")?.includes("session_token")) {
+        const headers = new Headers(c.req.raw.headers);
+        headers.set("Cookie", `__Secure-better-auth.session_token=${headerToken}`);
+        return stub.fetch(new Request(c.req.raw.url, { method: c.req.method, headers }));
+    }
     return stub.fetch(c.req.raw);
-});
-
-// Token exchange for Tauri deep-link auth
-app.post("/api/auth/create-token", async (c) => {
-    const session = await getSession(c.env, c.req.raw);
-    if (!session) return c.text("Unauthorized", 401);
-    const cookie = c.req.header("Cookie") || "";
-    const match = cookie.match(/better-auth\.session_token=([^;]+)/);
-    if (!match) return c.text("No session", 400);
-
-    const token = crypto.randomUUID();
-    const stub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
-    await stub.fetch(new Request("https://do/internal/tokens", {
-        method: "POST",
-        body: JSON.stringify({ token, sessionToken: match[1] }),
-    }));
-    return c.json({ token });
-});
-
-app.get("/api/auth/exchange-token", async (c) => {
-    const token = c.req.query("token");
-    if (!token) return c.text("Missing token", 400);
-
-    const stub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
-    const res = await stub.fetch(new Request(`https://do/internal/tokens?token=${token}`));
-    if (!res.ok) return c.text("Invalid or expired token", 401);
-    const { sessionToken } = await res.json() as { sessionToken: string };
-
-    return new Response(JSON.stringify({ ok: true }), {
-        headers: {
-            "Content-Type": "application/json",
-            "Set-Cookie": `better-auth.session_token=${sessionToken}; Path=/; HttpOnly; SameSite=Lax; Max-Age=604800`,
-        },
-    });
 });
 
 const requireAuth = async (c: any, next: any) => {


### PR DESCRIPTION
## Summary
- **Global hotkey (Cmd+Option+N)**: Toggles a floating, always-on-top quick note window for rapid capture
- **Quick notes architecture**: Uses sentinel `folder_id = "__quick_notes__"` — no schema migration, notes appear in a "Quick Notes" folder and can be promoted to normal notes
- **Desktop auth flow**: Full passkey auth via browser deep link with token exchange, supporting `X-Session-Token` header for cross-origin Tauri requests
- **Bug fixes**: Better Auth `__Secure-` cookie prefix handling, deep link JSON array payload parsing, route ordering for token endpoints

## Test plan
- [ ] Launch Notty.app, press Cmd+Option+N to open quick note window
- [ ] Create notes in the quick note window, verify they appear in main app under "Quick Notes" folder
- [ ] Cycle through quick notes with Cmd+[ and Cmd+]
- [ ] Test passkey auth flow from desktop app settings
- [ ] Verify cloud sync works after authentication
- [ ] Verify notty.page web app still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)