### PR TITLE
feat: overlay titlebar, tabs, and cloud sync for Tauri

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,10 @@
     "app": {
         "windows": [
             {
-                "title": "Notty",
+                "title": "",
+                "titleBarStyle": "Overlay",
+                "hiddenTitle": true,
+                "transparent": true,
                 "width": 1000,
                 "height": 700,
                 "minWidth": 600,

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/context/auth-context";
 import { NotesProvider } from "@/context/notes-context";
 import { FoldersProvider } from "@/context/folders-context";
 import { MediaProvider } from "@/context/media-context";
+import { TabsProvider } from "@/context/tabs-context";
 import type { NottyAdapter } from "@/lib/adapter";
 import { HomePage } from "./pages/home";
 import { NotePage } from "./pages/note";
@@ -44,15 +45,17 @@ getAdapter().then((adapter) => {
                         <NotesProvider>
                             <FoldersProvider>
                                 <MediaProvider>
-                                    <Routes>
-                                        <Route path="/" element={<HomePage />} />
-                                        <Route path="/trash" element={<TrashPage />} />
-                                        <Route path="/note/:id" element={<NotePage />} />
-                                        <Route path="/auth/passkey" element={<AuthPasskeyPage />} />
-                                        <Route path="/shared/:token" element={<SharedResolvePage />} />
-                                        <Route path="/settings/public" element={<PublicSettingsPage />} />
-                                        <Route path="/quick-note" element={<Suspense><QuickNotePage /></Suspense>} />
-                                    </Routes>
+                                    <TabsProvider>
+                                        <Routes>
+                                            <Route path="/" element={<HomePage />} />
+                                            <Route path="/trash" element={<TrashPage />} />
+                                            <Route path="/note/:id" element={<NotePage />} />
+                                            <Route path="/auth/passkey" element={<AuthPasskeyPage />} />
+                                            <Route path="/shared/:token" element={<SharedResolvePage />} />
+                                            <Route path="/settings/public" element={<PublicSettingsPage />} />
+                                            <Route path="/quick-note" element={<Suspense><QuickNotePage /></Suspense>} />
+                                        </Routes>
+                                    </TabsProvider>
                                 </MediaProvider>
                             </FoldersProvider>
                         </NotesProvider>

--- a/src/client/pages/home.tsx
+++ b/src/client/pages/home.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "react-router";
+import { useTabNavigate } from "@/context/tabs-context";
 import { LayoutGrid, List, Pencil, Image, Plus, Camera, FileUp } from "lucide-react";
 import { Drawer } from "vaul";
 import { AppLayout } from "@/components/app-layout";
@@ -46,6 +47,7 @@ function usePersistedView(): [ViewMode, (v: ViewMode) => void] {
 
 export function HomePage() {
     const navigate = useNavigate();
+    const tabNavigate = useTabNavigate();
     const { notes, loading, deleteNote, revalidate } = useNotes();
     const { folders, selectedFolderId, selectFolder, renameFolder, updateFolderDescription } = useFolders();
     const { media, uploadMedia, deleteMedia, publishMedia, updateCaption, getMediaUrl, revalidate: revalidateMedia } = useMedia();
@@ -132,8 +134,8 @@ export function HomePage() {
 
     const createAndNavigate = useCallback(() => {
         const id = crypto.randomUUID();
-        navigate(`/note/${id}${selectedFolderId ? `?folder=${selectedFolderId}` : ""}`, { viewTransition: true });
-    }, [navigate, selectedFolderId]);
+        tabNavigate(`/note/${id}${selectedFolderId ? `?folder=${selectedFolderId}` : ""}`, { title: "New Note" });
+    }, [tabNavigate, selectedFolderId]);
 
     useEffect(() => {
         if (selectedIndex < 0) return;
@@ -184,7 +186,7 @@ export function HomePage() {
         { key: "arrowdown", handler: () => setSelectedIndex((i) => Math.min(i + 1, totalItems - 1)) },
         { key: "k", handler: () => setSelectedIndex((i) => Math.max(i - 1, 0)) },
         { key: "arrowup", handler: () => setSelectedIndex((i) => Math.max(i - 1, 0)) },
-        { key: "enter", handler: () => { if (sorted[selectedIndex]) navigate(`/note/${sorted[selectedIndex].id}`, { viewTransition: true }); } },
+        { key: "enter", handler: () => { if (sorted[selectedIndex]) tabNavigate(`/note/${sorted[selectedIndex].id}`, { title: sorted[selectedIndex].title || "Untitled" }); } },
         { key: "x", handler: () => { if (sorted[selectedIndex]) { deleteNote(sorted[selectedIndex].id); setSelectedIndex((i) => Math.max(i - 1, 0)); } } },
         { key: "v", handler: () => setViewMode(viewMode === "grid" ? "timeline" : "grid") },
         { key: "s", handler: () => setSortMode((m) => m === "recent" ? "created" : "recent") },
@@ -354,7 +356,8 @@ export function HomePage() {
                                     }`} onClick={() => setSelectedIndex(i)}>
                                     {item.kind === "note" ? (
                                         <NoteCard note={item.data} onDelete={deleteNote} isDark={isDark}
-                                            folderName={folderNameMap.get(item.data.folder_id ?? "")} />
+                                            folderName={folderNameMap.get(item.data.folder_id ?? "")}
+                                            onOpen={(n) => tabNavigate(`/note/${n.id}`, { title: n.title || "Untitled" })} />
                                     ) : (
                                         <MediaCard item={item.data} mediaUrl={item.url}
                                             onDelete={deleteMedia} onTogglePublish={publishMedia}

--- a/src/client/pages/note.tsx
+++ b/src/client/pages/note.tsx
@@ -15,6 +15,8 @@ import { useAuth } from "@/context/auth-context";
 import { formatEntryDate } from "@/lib/date-utils";
 import { useHotkeys } from "@/lib/hotkeys";
 import { StorageBadge, OfflineBanner } from "@/components/sync-status";
+import { isTauri } from "@/lib/platform";
+import { useTabs } from "@/context/tabs-context";
 
 function NoteMenu({
     noteId,
@@ -150,6 +152,14 @@ export function NotePage() {
     const note = notes.find((n) => n.id === id);
     const effectiveFolderId = folderId || note?.folder_id || null;
 
+    // Update tab title when note title changes
+    const { updateTabTitle, activeTabId, closeTab } = useTabs();
+    useEffect(() => {
+        if (isTauri && activeTabId && note?.title) {
+            updateTabTitle(activeTabId, note.title);
+        }
+    }, [note?.title, activeTabId, updateTabTitle]);
+
     // Called AFTER the API call completes (guard already set by NoteHistory).
     // Cleans up stale state and remounts the editor.
     const handleContentReset = useCallback(async () => {
@@ -180,16 +190,17 @@ export function NotePage() {
         });
     }, [id, adapter, shareToken, authLoading, user]);
 
-    // Escape navigates back, preserving folder context
+    const handleBack = useCallback(() => {
+        if (effectiveFolderId) selectFolder(effectiveFolderId);
+        if (isTauri && activeTabId && activeTabId !== "home") {
+            closeTab(activeTabId);
+        } else {
+            navigate("/", { viewTransition: true });
+        }
+    }, [effectiveFolderId, selectFolder, activeTabId, closeTab, navigate]);
+
     useHotkeys([
-        {
-            key: "escape",
-            handler: () => {
-                if (effectiveFolderId) selectFolder(effectiveFolderId);
-                navigate("/", { viewTransition: true });
-            },
-            allowInInput: true,
-        },
+        { key: "escape", handler: handleBack, allowInInput: true },
     ]);
 
     // Auto-hide controls on desktop (hover: hover) only — touch devices always show
@@ -294,15 +305,18 @@ export function NotePage() {
     return (
         <div className="min-h-screen bg-[var(--color-paper)]" style={{ viewTransitionName: `note-${id}` }}>
             {/* Floating top bar */}
-            <div className={`fixed top-0 left-0 right-0 z-40 flex items-center justify-between px-3 sm:px-5 py-3 transition-opacity duration-500 ${showControls ? "opacity-100" : "opacity-0 pointer-events-none"}`}>
-                <Link
-                    to="/"
-                    viewTransition
+            <div
+                className={`fixed top-0 left-0 right-0 z-40 flex items-center justify-between px-3 sm:px-5 py-3 transition-opacity duration-500 ${showControls ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+                style={isTauri ? { paddingTop: 38 } : undefined}
+                {...(isTauri ? { "data-tauri-drag-region": true } : {})}
+            >
+                <button
+                    onClick={handleBack}
                     className="flex items-center gap-2 text-sm text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors px-3 py-1.5 rounded-lg hover:bg-[var(--color-sidebar-active)]"
                 >
                     <ArrowLeft size={16} />
                     <span className="font-serif italic hidden sm:inline">notty</span>
-                </Link>
+                </button>
 
                 <div className="flex items-center gap-1.5 sm:gap-2 text-[var(--color-ink-muted)]">
                     {/* Date — desktop only */}

--- a/src/client/pages/quick-note.tsx
+++ b/src/client/pages/quick-note.tsx
@@ -111,13 +111,12 @@ export function QuickNotePage() {
             <div
                 className="flex items-center justify-between px-3 py-2 border-b border-[var(--color-border-warm)] select-none shrink-0"
                 data-tauri-drag-region
-                style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
             >
                 <span className="text-xs text-[var(--color-ink-muted)] font-serif italic">
                     quick note
                 </span>
 
-                <div className="flex items-center gap-1" style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
+                <div className="flex items-center gap-1">
                     {quickNotes.length > 1 && (
                         <>
                             <button onClick={prev} className="p-1 rounded hover:bg-[var(--color-border-warm)] transition-colors" title="Previous (Cmd+[)">

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,10 +1,12 @@
 import { useState, type ReactNode, type CSSProperties } from "react";
 import { Sidebar } from "./sidebar";
+import { TabBar } from "./tab-bar";
 import { CommandPalette } from "./command-palette";
 import { ShortcutsHelp } from "./shortcuts-help";
 import { useFolders } from "@/context/folders-context";
 import { useHotkeys } from "@/lib/hotkeys";
 import { toggleDarkMode } from "@/lib/dark-mode";
+import { isTauri } from "@/lib/platform";
 
 export function AppLayout({ children }: { children: ReactNode }) {
     const { folders, selectedFolderId } = useFolders();
@@ -39,6 +41,8 @@ export function AppLayout({ children }: { children: ReactNode }) {
                 className="flex-1 overflow-y-auto transition-colors duration-300 min-w-0"
                 style={{ backgroundColor: folder?.color ? "var(--folder-tint)" : "var(--color-paper)" }}
             >
+                {/* Tab bar (Tauri) or plain drag region */}
+                {isTauri && <TabBar />}
                 {/* Mobile menu button */}
                 {!sidebarVisible && (
                     <button

--- a/src/components/auth-section.tsx
+++ b/src/components/auth-section.tsx
@@ -61,7 +61,7 @@ export function AuthSection() {
     const isAnonymous = user?.isAnonymous || !user?.email;
 
     useEffect(() => {
-        if (isAnonymous) return;
+        if (isAnonymous || isTauri) return;
         authClient.passkey.listUserPasskeys().then(({ data }) => {
             if (data && data.length > 0) setHasPasskey(true);
         });

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useNotes } from "@/context/notes-context";
 import { useFolders } from "@/context/folders-context";
 import { useAuth } from "@/context/auth-context";
+import { useTabNavigate } from "@/context/tabs-context";
 import { useHotkeys, isMac } from "@/lib/hotkeys";
 import { extractPreview } from "./note-card";
 import { toggleDarkMode } from "@/lib/dark-mode";
@@ -25,6 +26,7 @@ export function CommandPalette() {
     const inputRef = useRef<HTMLInputElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
     const navigate = useNavigate();
+    const tabNavigate = useTabNavigate();
     const { notes } = useNotes();
     const { folders, selectFolder } = useFolders();
     const { user, signOut } = useAuth();
@@ -43,9 +45,9 @@ export function CommandPalette() {
 
     const createNewNote = useCallback(() => {
         const id = crypto.randomUUID();
-        navigate(`/note/${id}`);
+        tabNavigate(`/note/${id}`, { title: "New Note" });
         close();
-    }, [navigate, close]);
+    }, [tabNavigate, close]);
 
     const toggleDark = useCallback(() => {
         toggleDarkMode();
@@ -96,12 +98,12 @@ export function CommandPalette() {
                 title: n.title || "Untitled",
                 subtitle: extractPreview(n.content).slice(0, 60),
                 section: "Notes",
-                action: () => { navigate(`/note/${n.id}`); close(); },
+                action: () => { tabNavigate(`/note/${n.id}`, { title: n.title || "Untitled" }); close(); },
             });
         }
 
         return items;
-    }, [notes, folders, createNewNote, toggleDark, navigate, selectFolder, close, isAnonymous, signOut]);
+    }, [notes, folders, createNewNote, toggleDark, navigate, tabNavigate, selectFolder, close, isAnonymous, signOut]);
 
     const filtered = useMemo(() => {
         if (!query.trim()) return commands;

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -258,9 +258,10 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         return () => { cancelled = true; };
     }, [noteId, ydoc, provider, adapter]);
 
-    // Connect WS after auth
+    // Connect WS after auth (web only — desktop uses local-first sync)
     useEffect(() => {
-        if (user && ready) provider.connect();
+        const isTauri = "__TAURI_INTERNALS__" in window;
+        if (user && ready && !isTauri) provider.connect();
     }, [user, ready, provider]);
 
     // Ref so unmount cleanup always calls the latest saveNow without dep churn

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -73,10 +73,11 @@ function formatYear(ts: number): string {
 }
 
 export function NoteCard({
-    note, onDelete, folderName, isDark,
+    note, onDelete, onOpen, folderName, isDark,
 }: {
     note: Note;
     onDelete: (id: string) => void;
+    onOpen?: (note: Note) => void;
     folderName?: string;
     isDark?: boolean;
 }) {
@@ -87,7 +88,12 @@ export function NoteCard({
     const date = formatDate(note.updated_at);
 
     return (
-        <Link to={`/note/${note.id}`} viewTransition className="block group">
+        <Link
+            to={`/note/${note.id}`}
+            viewTransition
+            className="block group"
+            onClick={onOpen ? (e) => { e.preventDefault(); onOpen(note); } : undefined}
+        >
             <div
                 className="rounded-l-md rounded-r-2xl overflow-hidden hover:-translate-y-1 hover:shadow-xl transition-all duration-200 min-h-[180px] flex flex-col shadow-[0_1px_3px_rgba(0,0,0,0.06)]"
                 style={{ backgroundColor: color.bg, viewTransitionName: `note-${note.id}` }}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -6,6 +6,8 @@ import { useAdapter } from "@/context/adapter-context";
 import { useAuth } from "@/context/auth-context";
 import { DarkModeToggle } from "./dark-mode-toggle";
 import { AuthSection } from "./auth-section";
+import { isTauri } from "@/lib/platform";
+import { useTabNavigate } from "@/context/tabs-context";
 import type { SharedNote } from "@/lib/adapter";
 
 const FOLDER_COLORS = [
@@ -15,6 +17,7 @@ const FOLDER_COLORS = [
 
 export function Sidebar() {
     const navigate = useNavigate();
+    const tabNavigate = useTabNavigate();
     const location = useLocation();
     const { folders, selectedFolderId, selectFolder, createFolder, deleteFolder, renameFolder } = useFolders();
     const { notes, trash } = useNotes();
@@ -75,8 +78,12 @@ export function Sidebar() {
 
     return (
         <aside className="w-60 h-screen flex flex-col border-r border-[var(--color-border-warm)] shrink-0 select-none transition-colors duration-300" style={{ backgroundColor: selectedFolderId ? "var(--folder-tint-sidebar, var(--color-sidebar))" : "var(--color-sidebar)" }}>
-            {/* Logo */}
-            <div className="px-5 pt-5 pb-4 flex items-center gap-2.5 border-b border-[var(--color-border-warm)]/50">
+            {/* Logo + drag region */}
+            <div
+                className="px-5 pb-4 flex items-center gap-2.5 border-b border-[var(--color-border-warm)]/50"
+                style={{ paddingTop: isTauri ? 38 : 20 }}
+                {...(isTauri ? { "data-tauri-drag-region": true } : {})}
+            >
                 <img src="/logo.png" className="w-7 h-7 rounded-lg" alt="" />
                 <span className="font-serif italic text-xl tracking-tight text-[var(--color-ink)]">notty</span>
             </div>
@@ -210,7 +217,7 @@ export function Sidebar() {
                         {sharedNotes.map((s) => (
                             <button
                                 key={s.id}
-                                onClick={() => navigate(`/note/${s.id}`)}
+                                onClick={() => tabNavigate(`/note/${s.id}`, { title: s.title || "Untitled" })}
                                 className="w-full flex items-center justify-between px-3 py-[7px] rounded-xl text-[13px] text-[var(--color-ink-muted)] hover:bg-[var(--color-sidebar-active)]/60 transition-colors"
                             >
                                 <span className="truncate">{s.title || "Untitled"}</span>

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -1,0 +1,50 @@
+import { useTabs } from "@/context/tabs-context";
+import { X } from "lucide-react";
+
+export function TabBar() {
+    const { tabs, activeTabId, switchTab, closeTab } = useTabs();
+
+    if (tabs.length <= 1) {
+        return (
+            <div className="h-10 w-full shrink-0" data-tauri-drag-region />
+        );
+    }
+
+    return (
+        <div
+            className="h-10 w-full shrink-0 flex items-end gap-0 px-2 border-b border-[var(--color-border-warm)]/30"
+            data-tauri-drag-region
+        >
+            {tabs.map(tab => {
+                const isActive = tab.id === activeTabId;
+                return (
+                    <button
+                        key={tab.id}
+                        onClick={() => switchTab(tab.id)}
+                        onMouseDown={(e) => {
+                            if (e.button === 1 && tab.id !== "home") {
+                                e.preventDefault();
+                                closeTab(tab.id);
+                            }
+                        }}
+                        className={`group relative flex items-center gap-1.5 px-3 h-8 max-w-[180px] text-[12px] rounded-t-lg transition-colors shrink-0 ${
+                            isActive
+                                ? "bg-[var(--color-paper)] text-[var(--color-ink)] font-medium"
+                                : "text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-paper)]/50"
+                        }`}
+                    >
+                        <span className="truncate">{tab.title}</span>
+                        {tab.id !== "home" && (
+                            <span
+                                onClick={(e) => { e.stopPropagation(); closeTab(tab.id); }}
+                                className="shrink-0 w-4 h-4 flex items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 hover:bg-[var(--color-border-warm)] transition-all"
+                            >
+                                <X size={10} />
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/context/tabs-context.tsx
+++ b/src/context/tabs-context.tsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from "react";
+import { useNavigate } from "react-router";
+import { isTauri } from "@/lib/platform";
+
+export type Tab = {
+    id: string;
+    path: string;
+    title: string;
+};
+
+type TabsContextType = {
+    tabs: Tab[];
+    activeTabId: string | null;
+    openTab: (path: string, title?: string) => void;
+    closeTab: (id: string) => void;
+    switchTab: (id: string) => void;
+    updateTabTitle: (id: string, title: string) => void;
+};
+
+const TabsContext = createContext<TabsContextType | null>(null);
+
+const HOME_TAB: Tab = { id: "home", path: "/", title: "All Notes" };
+
+export function TabsProvider({ children }: { children: ReactNode }) {
+    const navigate = useNavigate();
+    const [tabs, setTabs] = useState<Tab[]>([HOME_TAB]);
+    const [activeTabId, setActiveTabId] = useState("home");
+    const tabsRef = useRef(tabs);
+    tabsRef.current = tabs;
+
+    const openTab = useCallback((path: string, title?: string) => {
+        const existing = tabsRef.current.find(t => t.path === path);
+        if (existing) {
+            setActiveTabId(existing.id);
+        } else {
+            const id = path === "/" ? "home" : crypto.randomUUID();
+            setTabs(prev => [...prev, { id, path, title: title || "Untitled" }]);
+            setActiveTabId(id);
+        }
+        navigate(path);
+    }, [navigate]);
+
+    const closeTab = useCallback((id: string) => {
+        if (id === "home") return;
+        const current = tabsRef.current;
+        const idx = current.findIndex(t => t.id === id);
+        const next = current.filter(t => t.id !== id);
+        setTabs(next);
+        if (activeTabId === id) {
+            const newActive = next[Math.min(idx, next.length - 1)] || HOME_TAB;
+            setActiveTabId(newActive.id);
+            navigate(newActive.path);
+        }
+    }, [activeTabId, navigate]);
+
+    const switchTab = useCallback((id: string) => {
+        const tab = tabsRef.current.find(t => t.id === id);
+        if (tab) {
+            setActiveTabId(id);
+            navigate(tab.path);
+        }
+    }, [navigate]);
+
+    const updateTabTitle = useCallback((id: string, title: string) => {
+        setTabs(prev => prev.map(t => t.id === id ? { ...t, title } : t));
+    }, []);
+
+    return (
+        <TabsContext.Provider value={{ tabs, activeTabId, openTab, closeTab, switchTab, updateTabTitle }}>
+            {children}
+        </TabsContext.Provider>
+    );
+}
+
+export function useTabs() {
+    const ctx = useContext(TabsContext);
+    if (!ctx) throw new Error("useTabs must be used within TabsProvider");
+    return ctx;
+}
+
+/** Drop-in replacement for useNavigate that opens tabs in Tauri */
+export function useTabNavigate() {
+    const { openTab } = useTabs();
+    const navigate = useNavigate();
+
+    return useCallback((path: string, opts?: { title?: string }) => {
+        if (isTauri) {
+            openTab(path, opts?.title);
+        } else {
+            navigate(path);
+        }
+    }, [openTab, navigate]);
+}

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -19,6 +19,9 @@ export async function handleDeepLinkToken(url: string) {
         const store = await load("settings.json");
         await store.set("sessionToken", data.sessionToken);
         await store.save();
+        // Reset cloud detection so the new token gets picked up
+        const { resetCloudDetection } = await import("@/lib/desktop-adapter");
+        resetCloudDetection();
     }
     window.location.reload();
 }

--- a/src/lib/desktop-adapter.ts
+++ b/src/lib/desktop-adapter.ts
@@ -13,7 +13,7 @@ function syncMarkdown() {
     invoke("sync_to_markdown").catch(console.error);
 }
 
-// Cloud detection: runs once at startup, then caches.
+// Cloud detection: caches successful results, retries on failure.
 // Never blocks local operations — cloud sync is fire-and-forget.
 let cloudUrlCache: string | null | undefined = undefined; // undefined = not checked yet
 let cloudCheckPromise: Promise<string | null> | null = null;
@@ -36,27 +36,35 @@ function cloudFetch(url: string, init?: RequestInit): Promise<Response> {
 }
 
 async function detectCloud(): Promise<string | null> {
-    if (cloudUrlCache !== undefined) return cloudUrlCache;
+    if (cloudUrlCache) return cloudUrlCache; // cached success
     if (cloudCheckPromise) return cloudCheckPromise;
 
     cloudCheckPromise = (async () => {
         try {
             const settings = await getDesktopSettings();
             const url = settings.cloudUrl;
-            if (!url) { cloudUrlCache = null; return null; }
+            if (!url) return null;
             sessionTokenCache = settings.sessionToken;
+            if (!sessionTokenCache) {
+                console.warn("[notty] No session token — cloud sync disabled until sign-in");
+                return null;
+            }
             const res = await cloudFetch(`${url}/api/auth/get-session`, { signal: AbortSignal.timeout(2000) });
             if (res.ok) {
                 cloudUrlCache = url;
                 cloudAuthClient = createDesktopAuthClient(url);
                 return url;
             }
-        } catch {}
-        cloudUrlCache = null;
+            console.warn("[notty] Cloud session check failed:", res.status);
+        } catch (e) {
+            console.warn("[notty] Cloud detection failed:", e);
+        }
         return null;
     })();
 
-    return cloudCheckPromise;
+    const result = await cloudCheckPromise;
+    cloudCheckPromise = null; // don't cache failures — allow retry
+    return result;
 }
 
 export function resetCloudDetection() {
@@ -68,7 +76,9 @@ export function resetCloudDetection() {
 
 // Fire-and-forget cloud sync — never awaited, never blocks local ops
 function cloudSync(fn: (cloud: string) => void) {
-    detectCloud().then((cloud) => { if (cloud) fn(cloud); }).catch(() => {});
+    detectCloud().then((cloud) => {
+        if (cloud) fn(cloud);
+    }).catch((e) => console.warn("[notty] cloudSync error:", e));
 }
 
 export class DesktopAdapter implements NottyAdapter {
@@ -165,7 +175,7 @@ export class DesktopAdapter implements NottyAdapter {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(body),
-            }).catch(() => {});
+            }).catch((e) => console.warn("[notty] Cloud save failed:", e));
         });
     }
 


### PR DESCRIPTION
## Summary
- macOS overlay titlebar with draggable regions — no visible title bar, traffic lights float over content
- In-app tab bar for desktop (Tauri only) — open multiple notes as tabs, middle-click to close, titles update live
- Fix cloud sync silent failures — retry detection on failure, reset cache after auth, add console warnings
- Stop WebSocket/passkey 401 errors on desktop

## Test plan
- [ ] Launch Tauri app — verify no visible titlebar, traffic lights sit in sidebar
- [ ] Drag window from sidebar header and tab bar area
- [ ] Open multiple notes — verify tabs appear, switching works, closing works
- [ ] Sign in on desktop — verify cloud sync works (check console for `[notty]` warnings)
- [ ] Verify web app is unaffected (no tabs, no drag regions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)