### PR TITLE
fix: desktop-to-web real-time sync via Yjs WebSocket

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -205,9 +205,9 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         return () => clearInterval(interval);
     }, [saveNow]);
 
-    // Load: IndexedDB first (fast), then HTTP if Yjs doc is empty.
-    // We bootstrap HTTP content into the Yjs doc directly (via a temporary
-    // TipTap editor) so the Collaboration extension renders it exactly once.
+    // Load: IndexedDB + HTTP in parallel. HTTP content is authoritative —
+    // it may be newer than IndexedDB (e.g. desktop edited via HTTP while
+    // web's Yjs state was stale). We bootstrap into the Yjs doc via TipTap.
     const bootstrapRef = useRef<JSONContent | null>(null);
     useEffect(() => {
         let cancelled = false;
@@ -215,44 +215,33 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         const persistenceReady = provider.persistence
             ? provider.persistence.whenSynced
             : Promise.resolve();
-        // In compact mode (quick notes), always wait for IndexedDB — no timeout race.
-        // In normal mode, race with 150ms to avoid blocking on slow persistence.
         const waitForPersistence = compact
             ? persistenceReady
             : Promise.race([persistenceReady, new Promise((r) => setTimeout(r, 150))]);
-        waitForPersistence.then(() => {
+
+        // Shared notes get content from WebSocket sync — skip HTTP bootstrap
+        if (shareToken) {
+            waitForPersistence.then(() => { if (!cancelled) setReady(true); });
+            return () => { cancelled = true; };
+        }
+
+        // Fetch HTTP content in parallel with IndexedDB
+        const httpContent = Promise.race([
+            adapter.getNote(noteId).catch(() => null),
+            new Promise((r) => setTimeout(() => r(null), 500)),
+        ]);
+
+        Promise.all([waitForPersistence, httpContent]).then(([, data]: [any, any]) => {
             if (cancelled) return;
-
-            const hasYjsContent = ydoc.getXmlFragment("default").length > 1;
-
-            if (hasYjsContent) {
-                setReady(true);
-                return;
+            if (data?.content) {
+                try {
+                    const parsed = typeof data.content === "string" ? JSON.parse(data.content) : data.content;
+                    if (parsed?.type === "doc" && parsed.content?.length) {
+                        bootstrapRef.current = parsed;
+                    }
+                } catch {}
             }
-
-            // Shared notes get content from WebSocket sync — skip HTTP bootstrap
-            // to avoid duplicate content (HTTP + Yjs sync create independent ops)
-            if (shareToken) {
-                setReady(true);
-                return;
-            }
-
-            // Yjs doc is empty — try to bootstrap from HTTP
-            Promise.race([
-                adapter.getNote(noteId, shareToken).catch(() => null),
-                new Promise((r) => setTimeout(() => r(null), 500)),
-            ]).then((data: any) => {
-                if (cancelled) return;
-                if (data?.content && ydoc.getXmlFragment("default").length <= 1) {
-                    try {
-                        const parsed = typeof data.content === "string" ? JSON.parse(data.content) : data.content;
-                        if (parsed?.type === "doc" && parsed.content?.length) {
-                            bootstrapRef.current = parsed;
-                        }
-                    } catch {}
-                }
-                setReady(true);
-            });
+            setReady(true);
         });
 
         return () => { cancelled = true; };
@@ -395,7 +384,7 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                     }}
                     onCreate={({ editor }) => {
                         editorRef.current = editor;
-                        if (bootstrapRef.current && !editor.getText().trim()) {
+                        if (bootstrapRef.current) {
                             editor.commands.setContent(bootstrapRef.current);
                             bootstrapRef.current = null;
                         }

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -205,9 +205,9 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         return () => clearInterval(interval);
     }, [saveNow]);
 
-    // Load: IndexedDB + HTTP in parallel. HTTP content is authoritative —
-    // it may be newer than IndexedDB (e.g. desktop edited via HTTP while
-    // web's Yjs state was stale). We bootstrap into the Yjs doc via TipTap.
+    // Load: IndexedDB + HTTP in parallel. Only bootstrap from HTTP when the
+    // Yjs doc is empty — setContent on a non-empty Collaboration doc creates
+    // independent Yjs ops that merge/duplicate with existing server state.
     const bootstrapRef = useRef<JSONContent | null>(null);
     useEffect(() => {
         let cancelled = false;
@@ -225,21 +225,25 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
             return () => { cancelled = true; };
         }
 
-        // Fetch HTTP content in parallel with IndexedDB
+        // Fetch HTTP content in parallel with IndexedDB (no added latency)
         const httpContent = Promise.race([
-            adapter.getNote(noteId).catch(() => null),
-            new Promise((r) => setTimeout(() => r(null), 500)),
+            adapter.getNote(noteId).catch((e) => { console.warn("[notty] HTTP bootstrap fetch failed:", e); return null; }),
+            new Promise((r) => setTimeout(() => r(null), 1000)),
         ]);
 
         Promise.all([waitForPersistence, httpContent]).then(([, data]: [any, any]) => {
             if (cancelled) return;
-            if (data?.content) {
+            const hasYjsContent = ydoc.getXmlFragment("default").length > 1;
+            // Only bootstrap when Yjs doc is empty to prevent CRDT duplication
+            if (!hasYjsContent && data?.content) {
                 try {
                     const parsed = typeof data.content === "string" ? JSON.parse(data.content) : data.content;
                     if (parsed?.type === "doc" && parsed.content?.length) {
                         bootstrapRef.current = parsed;
                     }
-                } catch {}
+                } catch (e) {
+                    console.warn("[notty] Failed to parse bootstrap content:", e);
+                }
             }
             setReady(true);
         });
@@ -384,7 +388,7 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                     }}
                     onCreate={({ editor }) => {
                         editorRef.current = editor;
-                        if (bootstrapRef.current) {
+                        if (bootstrapRef.current && !editor.getText().trim()) {
                             editor.commands.setContent(bootstrapRef.current);
                             bootstrapRef.current = null;
                         }
@@ -450,7 +454,7 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                         <span className="hidden group-hover:inline">{wordCount.toLocaleString()} words · {charCount.toLocaleString()} chars · {Math.max(1, Math.ceil(wordCount / 250))}p</span>
                     </span>
                     <span className="pointer-events-auto">
-                        <SaveIndicator saveState={saveState} />
+                        <SaveIndicator saveState={saveState} cloudConnected={provider.connected} />
                     </span>
                 </div>
             )}

--- a/src/components/sync-status.tsx
+++ b/src/components/sync-status.tsx
@@ -3,12 +3,11 @@ import { isTauri } from "@/lib/platform";
 
 type SaveState = "idle" | "saving" | "saved" | "offline-saved";
 
-export function SaveIndicator({ saveState }: { saveState: SaveState }) {
+export function SaveIndicator({ saveState, cloudConnected }: { saveState: SaveState; cloudConnected?: boolean }) {
     const online = useOnlineStatus();
 
     if (saveState === "idle") return null;
 
-    // Determine what to show
     let dotColor: string;
     let label: string;
     let sublabel: string | null = null;
@@ -19,7 +18,7 @@ export function SaveIndicator({ saveState }: { saveState: SaveState }) {
         sublabel = "Will sync when online";
     } else if (isTauri) {
         dotColor = saveState === "saving" ? "bg-amber-500" : "bg-emerald-500";
-        label = saveState === "saving" ? "Saving…" : "Saved";
+        label = saveState === "saving" ? "Saving…" : (cloudConnected ? "Saved" : "Saved locally");
     } else {
         dotColor = saveState === "saving" ? "bg-amber-500" : "bg-emerald-500";
         label = saveState === "saving" ? "Saving…" : "Saved";

--- a/src/components/sync-status.tsx
+++ b/src/components/sync-status.tsx
@@ -19,7 +19,7 @@ export function SaveIndicator({ saveState }: { saveState: SaveState }) {
         sublabel = "Will sync when online";
     } else if (isTauri) {
         dotColor = saveState === "saving" ? "bg-amber-500" : "bg-emerald-500";
-        label = saveState === "saving" ? "Saving…" : "Saved locally";
+        label = saveState === "saving" ? "Saving…" : "Saved";
     } else {
         dotColor = saveState === "saving" ? "bg-amber-500" : "bg-emerald-500";
         label = saveState === "saving" ? "Saving…" : "Saved";

--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -382,17 +382,26 @@ export class UserNotesDurableObject extends DurableObject {
             const existing = this.getNote(id);
 
             if (existing) {
-                this.sql.exec(
-                    `UPDATE notes SET title = ?, content = ?, yjs_state = NULL, folder_id = ?, sync_mode = ?, updated_at = unixepoch() WHERE id = ?`,
-                    body.title || "Untitled", body.content || "",
-                    body.folder_id !== undefined ? body.folder_id : existing.folder_id,
-                    body.sync_mode !== undefined ? body.sync_mode : existing.sync_mode,
-                    id
-                );
-                // Evict stale Yjs doc so next WebSocket client starts fresh
-                this.docs.delete(id);
-                const timer = this.saveTimers.get(id);
-                if (timer) { clearTimeout(timer); this.saveTimers.delete(id); }
+                const hasActiveYjs = this.docs.has(id);
+                if (hasActiveYjs) {
+                    // Yjs WebSocket is the source of truth — only update metadata columns
+                    this.sql.exec(
+                        `UPDATE notes SET title = ?, content = ?, folder_id = ?, sync_mode = ?, updated_at = unixepoch() WHERE id = ?`,
+                        body.title || "Untitled", body.content || "",
+                        body.folder_id !== undefined ? body.folder_id : existing.folder_id,
+                        body.sync_mode !== undefined ? body.sync_mode : existing.sync_mode,
+                        id
+                    );
+                } else {
+                    // No active Yjs session — null stale yjs_state so next client bootstraps from HTTP
+                    this.sql.exec(
+                        `UPDATE notes SET title = ?, content = ?, yjs_state = NULL, folder_id = ?, sync_mode = ?, updated_at = unixepoch() WHERE id = ?`,
+                        body.title || "Untitled", body.content || "",
+                        body.folder_id !== undefined ? body.folder_id : existing.folder_id,
+                        body.sync_mode !== undefined ? body.sync_mode : existing.sync_mode,
+                        id
+                    );
+                }
                 if (body.content) this.createVersion(id, body.title || "Untitled", body.content);
             } else {
                 this.sql.exec(

--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -382,7 +382,7 @@ export class UserNotesDurableObject extends DurableObject {
             const existing = this.getNote(id);
 
             if (existing) {
-                const hasActiveYjs = this.docs.has(id);
+                const hasActiveYjs = this.ctx.getWebSockets(id).length > 0;
                 if (hasActiveYjs) {
                     // Yjs WebSocket is the source of truth — only update metadata columns
                     this.sql.exec(

--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -383,12 +383,16 @@ export class UserNotesDurableObject extends DurableObject {
 
             if (existing) {
                 this.sql.exec(
-                    `UPDATE notes SET title = ?, content = ?, folder_id = ?, sync_mode = ?, updated_at = unixepoch() WHERE id = ?`,
+                    `UPDATE notes SET title = ?, content = ?, yjs_state = NULL, folder_id = ?, sync_mode = ?, updated_at = unixepoch() WHERE id = ?`,
                     body.title || "Untitled", body.content || "",
                     body.folder_id !== undefined ? body.folder_id : existing.folder_id,
                     body.sync_mode !== undefined ? body.sync_mode : existing.sync_mode,
                     id
                 );
+                // Evict stale Yjs doc so next WebSocket client starts fresh
+                this.docs.delete(id);
+                const timer = this.saveTimers.get(id);
+                if (timer) { clearTimeout(timer); this.saveTimers.delete(id); }
                 if (body.content) this.createVersion(id, body.title || "Untitled", body.content);
             } else {
                 this.sql.exec(

--- a/src/lib/desktop-adapter.ts
+++ b/src/lib/desktop-adapter.ts
@@ -322,7 +322,14 @@ export class DesktopAdapter implements NottyAdapter {
     async updateProfile(): Promise<void> { throw new Error("Profile requires cloud"); }
 
     createProvider(noteId: string, doc: Y.Doc): NottyProvider {
-        // Desktop: offline-only Yjs (IndexedDB persistence, no WebSocket)
-        return new NottyProvider(noteId, doc, { connect: false });
+        const provider = new NottyProvider(noteId, doc, { connect: false });
+        // When cloud is available, connect Yjs WebSocket for real-time sync
+        detectCloud().then((cloud) => {
+            if (cloud && !provider.destroyed && sessionTokenCache) {
+                provider.setServerUrl(cloud, sessionTokenCache);
+                provider.connect();
+            }
+        });
+        return provider;
     }
 }

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -13,24 +13,26 @@ export class NottyProvider {
     awareness: awarenessProtocol.Awareness;
     persistence: IndexeddbPersistence | null;
     private ws: WebSocket | null = null;
-    private connected = false;
-    private destroyed = false;
+    connected = false;
+    destroyed = false;
     private pendingUpdates: Uint8Array[] = [];
     private serverUrl: string | null = null;
     private reconnectDelay = 1000;
 
     private shareToken: string | undefined;
+    private authToken: string | undefined;
     private offlineOnly: boolean;
 
     constructor(
         private noteId: string,
         doc: Y.Doc,
-        options?: { connect?: boolean; shareToken?: string }
+        options?: { connect?: boolean; shareToken?: string; token?: string }
     ) {
         this.doc = doc;
         this.awareness = new awarenessProtocol.Awareness(doc);
         this.offlineOnly = options?.connect === false;
         this.shareToken = options?.shareToken;
+        this.authToken = options?.token;
 
         // Offline persistence — skip for shared notes (no offline use, avoids stale duplicates)
         this.persistence = options?.shareToken
@@ -61,12 +63,13 @@ export class NottyProvider {
         if (options?.connect !== false) this.connect();
     }
 
-    setServerUrl(url: string) {
+    setServerUrl(url: string, token?: string) {
         this.serverUrl = url;
+        if (token) this.authToken = token;
     }
 
     connect() {
-        if (this.destroyed) return;
+        if (this.destroyed || this.connected) return;
         this.offlineOnly = false;
         let wsUrl: string;
         if (this.serverUrl) {
@@ -74,6 +77,7 @@ export class NottyProvider {
             const host = this.serverUrl.replace(/^https?:\/\//, "");
             wsUrl = `${proto}//${host}/api/sync?noteId=${this.noteId}`;
             if (this.shareToken) wsUrl += `&share=${encodeURIComponent(this.shareToken)}`;
+            if (this.authToken) wsUrl += `&token=${encodeURIComponent(this.authToken)}`;
         } else {
             const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
             wsUrl = `${proto}//${window.location.host}/api/sync?noteId=${this.noteId}`;

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -69,7 +69,7 @@ export class NottyProvider {
     }
 
     connect() {
-        if (this.destroyed || this.connected) return;
+        if (this.destroyed || this.connected || this.ws) return;
         this.offlineOnly = false;
         let wsUrl: string;
         if (this.serverUrl) {
@@ -134,9 +134,8 @@ export class NottyProvider {
         };
 
         ws.onclose = (event) => {
+            this.ws = null;
             this.connected = false;
-            // Don't reconnect if destroyed or if server closed for content-reset
-            // (checkout/restore/merge — editor will remount with fresh state)
             if (!this.destroyed && event.code !== 4000) {
                 this.reconnectDelay = Math.min((this.reconnectDelay || 1000) * 2, 30000);
                 setTimeout(() => this.connect(), this.reconnectDelay);
@@ -144,6 +143,7 @@ export class NottyProvider {
         };
 
         ws.onerror = () => {
+            console.warn("[notty] WebSocket error for note", this.noteId);
             this.connected = false;
             ws.close();
         };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -94,14 +94,15 @@ async function getSession(env: Env, request: Request) {
     const stub = env.AUTH_DO.get(env.AUTH_DO.idFromName("auth-singleton"));
     const url = new URL(request.url);
     const headers = new Headers();
-    // Forward existing cookie, or inject from X-Session-Token header
+    // Forward existing cookie, or inject from X-Session-Token header / query param
     const existingCookie = request.headers.get("Cookie");
     const headerToken = request.headers.get("X-Session-Token");
+    const queryToken = url.searchParams.get("token");
     if (existingCookie) {
         headers.set("Cookie", existingCookie);
-    } else if (headerToken) {
+    } else if (headerToken || queryToken) {
         // Use __Secure- prefix since the DO request URL is https://
-        headers.set("Cookie", `__Secure-better-auth.session_token=${headerToken}`);
+        headers.set("Cookie", `__Secure-better-auth.session_token=${headerToken || queryToken}`);
     }
     const res = await stub.fetch(new Request(`${url.origin}/api/auth/get-session`, { headers }));
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- Desktop now connects to cloud Yjs WebSocket when signed in, so edits sync in real-time to web (and vice versa)
- Server nulls stale `yjs_state` on HTTP saves (when no active WebSocket session) so web clients bootstrap fresh content
- Editor bootstraps from HTTP in parallel with IndexedDB for faster load, with emptiness guards to prevent CRDT duplication
- Sync status shows "Saved locally" on desktop when cloud WebSocket isn't connected

## What was broken
Desktop saved notes via fire-and-forget HTTP POST, which updated the `content` column but never the `yjs_state` blob. Web editor loaded from Yjs state (stale/empty), ignoring newer HTTP content. Previews showed correct content (read from HTTP) but the editor didn't.

## Key changes
- **`yjs-provider.ts`**: Auth token support for WebSocket URL, idempotent `connect()` with `this.ws` guard, null ws ref on close for clean reconnect
- **`server/index.ts`**: Accept auth token via `?token=` query param (WebSocket can't set headers)
- **`desktop-adapter.ts`**: Connect Yjs WebSocket to cloud when available (async, guarded against destroyed provider)
- **`user-notes.ts`**: Null `yjs_state` + check `getWebSockets().length` (not docs cache) for active session detection
- **`editor.tsx`**: Parallel HTTP+IndexedDB fetch, emptiness guards on bootstrap, error logging
- **`sync-status.tsx`**: `cloudConnected` prop to distinguish local vs cloud save

## Test plan
- [ ] Edit note on desktop → verify changes appear on web in real-time
- [ ] Edit note on web → verify changes appear on desktop editor
- [ ] Open note on web that was only edited on desktop → content should load correctly
- [ ] Edit note on web with two tabs open → verify collab still works (no duplication)
- [ ] Desktop with no cloud configured → should show "Saved locally", no WebSocket errors
- [ ] Desktop with expired session → should gracefully fall back to local-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)