### PR TITLE
fix: prevent Yjs content doubling during multi-client sync

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -205,9 +205,10 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         return () => clearInterval(interval);
     }, [saveNow]);
 
-    // Load: IndexedDB + HTTP in parallel. Only bootstrap from HTTP when the
-    // Yjs doc is empty — setContent on a non-empty Collaboration doc creates
-    // independent Yjs ops that merge/duplicate with existing server state.
+    // Load: IndexedDB + WebSocket sync in parallel. Only bootstrap from HTTP
+    // when the Yjs doc is STILL empty after both complete — setContent on a
+    // non-empty Collaboration doc creates independent Yjs ops that
+    // merge/duplicate with existing server state.
     const bootstrapRef = useRef<JSONContent | null>(null);
     useEffect(() => {
         let cancelled = false;
@@ -225,16 +226,23 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
             return () => { cancelled = true; };
         }
 
-        // Fetch HTTP content in parallel with IndexedDB (no added latency)
+        // Fetch HTTP content in parallel (no added latency)
         const httpContent = Promise.race([
             adapter.getNote(noteId).catch((e) => { console.warn("[notty] HTTP bootstrap fetch failed:", e); return null; }),
             new Promise((r) => setTimeout(() => r(null), 1000)),
         ]);
 
-        Promise.all([waitForPersistence, httpContent]).then(([, data]: [any, any]) => {
+        // Wait for WebSocket sync too (with timeout) so we don't bootstrap
+        // content that's about to arrive via Yjs — that causes CRDT duplication
+        const wsSync = Promise.race([
+            provider.whenSynced,
+            new Promise((r) => setTimeout(r, 2000)),
+        ]);
+
+        Promise.all([waitForPersistence, httpContent, wsSync]).then(([, data]: [any, any, any]) => {
             if (cancelled) return;
             const hasYjsContent = ydoc.getXmlFragment("default").length > 1;
-            // Only bootstrap when Yjs doc is empty to prevent CRDT duplication
+            // Only bootstrap when Yjs doc is empty after all sync sources exhausted
             if (!hasYjsContent && data?.content) {
                 try {
                     const parsed = typeof data.content === "string" ? JSON.parse(data.content) : data.content;
@@ -251,11 +259,12 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
         return () => { cancelled = true; };
     }, [noteId, ydoc, provider, adapter]);
 
-    // Connect WS after auth (web only — desktop uses local-first sync)
+    // Connect WS early so sync completes before bootstrap decision.
+    // Desktop connects via detectCloud() in the adapter instead.
     useEffect(() => {
         const isTauri = "__TAURI_INTERNALS__" in window;
-        if (user && ready && !isTauri) provider.connect();
-    }, [user, ready, provider]);
+        if (user && !isTauri) provider.connect();
+    }, [user, provider]);
 
     // Ref so unmount cleanup always calls the latest saveNow without dep churn
     const saveNowRef = useRef(saveNow);

--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -150,7 +150,21 @@ export class UserNotesDurableObject extends DurableObject {
             Y.applyUpdate(doc, new Uint8Array(rows[0].yjs_state as ArrayBuffer));
         }
 
-        doc.on("update", () => {
+        doc.on("update", (update: Uint8Array, origin: any) => {
+            // Broadcast to all connected clients except the sender.
+            // origin is the WebSocket that caused this update (null for DB loads).
+            if (origin) {
+                const encoder = encoding.createEncoder();
+                encoding.writeVarUint(encoder, MSG_SYNC);
+                syncProtocol.writeUpdate(encoder, update);
+                const msg = encoding.toUint8Array(encoder);
+                for (const other of this.ctx.getWebSockets(noteId)) {
+                    if (other !== origin) {
+                        try { other.send(msg); } catch { other.close(); }
+                    }
+                }
+            }
+
             const existing = this.saveTimers.get(noteId);
             if (existing) clearTimeout(existing);
             this.saveTimers.set(noteId, setTimeout(() => {
@@ -795,7 +809,6 @@ export class UserNotesDurableObject extends DurableObject {
         if (msgType === MSG_SYNC) {
             // View-only users receive sync (get the doc) but can't push changes
             if (permission === "view") {
-                // Still respond to sync step 1 (so they get the doc), but don't apply or broadcast
                 const encoder = encoding.createEncoder();
                 encoding.writeVarUint(encoder, MSG_SYNC);
                 syncProtocol.readSyncMessage(decoder, encoder, doc, null);
@@ -804,9 +817,10 @@ export class UserNotesDurableObject extends DurableObject {
             }
             const encoder = encoding.createEncoder();
             encoding.writeVarUint(encoder, MSG_SYNC);
-            syncProtocol.readSyncMessage(decoder, encoder, doc, null);
+            // Pass ws as origin so the doc update handler can broadcast
+            // to all clients EXCEPT the sender
+            syncProtocol.readSyncMessage(decoder, encoder, doc, ws);
             if (encoding.length(encoder) > 1) ws.send(encoding.toUint8Array(encoder));
-            broadcast(data);
         } else if (msgType === MSG_AWARENESS) {
             // Awareness always flows (presence is visible for all)
             broadcast(data);

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -15,9 +15,12 @@ export class NottyProvider {
     private ws: WebSocket | null = null;
     connected = false;
     destroyed = false;
+    synced = false;
     private pendingUpdates: Uint8Array[] = [];
     private serverUrl: string | null = null;
     private reconnectDelay = 1000;
+    private _syncResolve: (() => void) | null = null;
+    whenSynced: Promise<void>;
 
     private shareToken: string | undefined;
     private authToken: string | undefined;
@@ -33,6 +36,7 @@ export class NottyProvider {
         this.offlineOnly = options?.connect === false;
         this.shareToken = options?.shareToken;
         this.authToken = options?.token;
+        this.whenSynced = new Promise((r) => { this._syncResolve = r; });
 
         // Offline persistence — skip for shared notes (no offline use, avoids stale duplicates)
         this.persistence = options?.shareToken
@@ -123,9 +127,14 @@ export class NottyProvider {
             if (msgType === MSG_SYNC) {
                 const encoder = encoding.createEncoder();
                 encoding.writeVarUint(encoder, MSG_SYNC);
-                syncProtocol.readSyncMessage(decoder, encoder, this.doc, this);
+                const syncType = syncProtocol.readSyncMessage(decoder, encoder, this.doc, this);
                 if (encoding.length(encoder) > 1) {
                     ws.send(encoding.toUint8Array(encoder));
+                }
+                // SyncStep2 (1) means the server sent us its state — initial sync is done
+                if (syncType === 1 && !this.synced) {
+                    this.synced = true;
+                    this._syncResolve?.();
                 }
             } else if (msgType === MSG_AWARENESS) {
                 const update = decoding.readVarUint8Array(decoder);


### PR DESCRIPTION
## Summary
- **HTTP bootstrap race**: `setContent` was creating new CRDT ops before WebSocket sync completed, so when the server's original ops arrived, Yjs merged both sets — doubling the content
- **Server broadcast bug**: Raw sync handshake messages (SyncStep1/2) were broadcast to all clients instead of only actual document updates, causing cascading sync responses
- Fix waits for WebSocket sync (2s timeout) before bootstrap, connects WS early, and moves broadcast into Y.Doc update event handler (matching standard y-websocket behavior)

## Test plan
- [ ] Open same note on two browser tabs simultaneously — content should not double
- [ ] Cycle through quicknotes on desktop while same note is open on web — no duplication
- [ ] Open a note for the first time (empty IndexedDB) — content loads correctly from server via Yjs sync
- [ ] Offline mode still works — bootstrap from HTTP fires after 2s timeout if no WS available
- [ ] Shared notes still sync correctly between editor and viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)