### PR TITLE
feat: inline image support in the blog editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@tauri-apps/plugin-store": "^2.4.2",
 				"@tiptap/extension-collaboration": "^2.0.0",
 				"@tiptap/extension-collaboration-cursor": "^2.0.0",
+				"@tiptap/extension-image": "^2.11.2",
 				"@vitejs/plugin-react": "^6.0.1",
 				"better-auth": "^1.5.6",
 				"drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tauri-apps/plugin-store": "^2.4.2",
 		"@tiptap/extension-collaboration": "^2.0.0",
 		"@tiptap/extension-collaboration-cursor": "^2.0.0",
+		"@tiptap/extension-image": "^2.11.2",
 		"@vitejs/plugin-react": "^6.0.1",
 		"better-auth": "^1.5.6",
 		"drizzle-orm": "^0.45.2",

--- a/src/components/editor-extensions.tsx
+++ b/src/components/editor-extensions.tsx
@@ -13,7 +13,9 @@ import {
     Command,
     createSuggestionItems,
     renderItems,
+    UploadImagesPlugin,
 } from "novel";
+import TiptapImage from "@tiptap/extension-image";
 import {
     Heading1Icon,
     Heading2Icon,
@@ -25,7 +27,9 @@ import {
     MinusIcon,
     CodeXmlIcon,
     TextIcon,
+    ImageIcon,
 } from "lucide-react";
+import { uploadFn } from "@/lib/image-upload";
 
 export const suggestionItems = createSuggestionItems([
     {
@@ -110,6 +114,26 @@ export const suggestionItems = createSuggestionItems([
         },
     },
     {
+        title: "Image",
+        description: "Upload an image from your device",
+        icon: <ImageIcon size={18} />,
+        searchTerms: ["image", "photo", "picture", "media", "upload"],
+        command: ({ editor, range }) => {
+            editor.chain().focus().deleteRange(range).run();
+            const input = document.createElement("input");
+            input.type = "file";
+            input.accept = "image/*";
+            input.onchange = () => {
+                const file = input.files?.[0];
+                if (file) {
+                    const pos = editor.view.state.selection.from;
+                    uploadFn(file, editor.view, pos);
+                }
+            };
+            input.click();
+        },
+    },
+    {
         title: "Divider",
         description: "Horizontal rule",
         icon: <MinusIcon size={18} />,
@@ -124,6 +148,23 @@ const slashCommand = Command.configure({
     suggestion: {
         items: () => suggestionItems,
         render: renderItems,
+    },
+});
+
+// Image node with novel's upload placeholder plugin (shows a spinner-styled
+// preview while the file uploads to R2, then swaps in the real <img>).
+const tiptapImage = TiptapImage.extend({
+    addProseMirrorPlugins() {
+        return [
+            UploadImagesPlugin({
+                imageClass: "opacity-40 rounded-lg border border-[var(--color-border-warm)]",
+            }),
+        ];
+    },
+}).configure({
+    allowBase64: false,
+    HTMLAttributes: {
+        class: "rounded-lg border border-[var(--color-border-warm)] my-4 max-w-full",
     },
 });
 
@@ -153,6 +194,7 @@ export const extensions = [
     }),
     TaskList.configure({ HTMLAttributes: { class: "not-prose" } }),
     TaskItem.configure({ nested: true }),
+    tiptapImage,
     HorizontalRule,
     CharacterCount,
     TiptapUnderline,

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -8,10 +8,14 @@ import {
     EditorCommandEmpty,
     EditorBubble,
     EditorBubbleItem,
+    ImageResizer,
     type JSONContent,
     type EditorInstance,
     handleCommandNavigation,
+    handleImagePaste,
+    handleImageDrop,
 } from "novel";
+import { uploadFn } from "@/lib/image-upload";
 import { useDebouncedCallback } from "use-debounce";
 import { deriveTitle } from "@/lib/note-preview";
 import {
@@ -512,6 +516,8 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                         handleDOMEvents: {
                             keydown: (_view, event) => readOnly ? false : handleCommandNavigation(event),
                         },
+                        handlePaste: (view, event) => readOnly ? false : handleImagePaste(view, event, uploadFn),
+                        handleDrop: (view, event, _slice, moved) => readOnly ? false : handleImageDrop(view, event, moved, uploadFn),
                         attributes: {
                             class: `focus:outline-none max-w-full ${compact ? "min-h-[180px]" : "min-h-[400px]"} ${readOnly ? "select-text" : ""}`,
                         },
@@ -575,6 +581,8 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                             </EditorCommandList>
                         </EditorCommand>
                     )}
+
+                    {!readOnly && <ImageResizer />}
                 </EditorContent>
             </EditorRoot>
 

--- a/src/lib/image-upload.ts
+++ b/src/lib/image-upload.ts
@@ -1,0 +1,71 @@
+import { createImageUpload } from "novel";
+import { toast } from "sonner";
+
+const MAX_SIZE_MB = 50;
+
+// Read the natural pixel dimensions of an image file so the server can
+// persist them (used for layout hints + the resize handles).
+function getImageDimensions(file: File): Promise<{ width: number; height: number } | undefined> {
+    return new Promise((resolve) => {
+        const url = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = () => {
+            URL.revokeObjectURL(url);
+            resolve({ width: img.naturalWidth, height: img.naturalHeight });
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(url);
+            resolve(undefined);
+        };
+        img.src = url;
+    });
+}
+
+// Upload an image file to R2 via the media API and resolve to the URL the
+// editor should reference. The same path is used by paste, drop, and the
+// "/image" slash command. We hit /api/media directly (rather than the adapter)
+// so this can run from the static extensions module without React context.
+export const uploadFn = createImageUpload({
+    validateFn: (file) => {
+        if (!file.type.startsWith("image/")) {
+            toast.error("Only image files can be inserted here.");
+            return false;
+        }
+        if (file.size / 1024 / 1024 > MAX_SIZE_MB) {
+            toast.error(`Image is too large (max ${MAX_SIZE_MB}MB).`);
+            return false;
+        }
+        return true;
+    },
+    onUpload: async (file) => {
+        const dimensions = await getImageDimensions(file);
+        const form = new FormData();
+        form.append("file", file);
+        if (dimensions) {
+            form.append("width", String(dimensions.width));
+            form.append("height", String(dimensions.height));
+        }
+
+        const promise = fetch("/api/media", { method: "POST", body: form }).then(async (res) => {
+            if (!res.ok) throw new Error(await res.text().catch(() => "Upload failed"));
+            const media = (await res.json()) as { id: string };
+            const src = `/api/media/${media.id}/file`;
+            // Preload so the swap from placeholder → image is instant and
+            // novel can measure the loaded element.
+            return new Promise<string>((resolve) => {
+                const img = new Image();
+                img.src = src;
+                img.onload = () => resolve(src);
+                img.onerror = () => resolve(src);
+            });
+        });
+
+        toast.promise(promise, {
+            loading: "Uploading image…",
+            success: "Image uploaded",
+            error: (e) => (e instanceof Error ? e.message : "Failed to upload image"),
+        });
+
+        return await promise;
+    },
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -509,7 +509,28 @@ app.post("/api/notes/:id/publish", async (c) => {
     const session = await getSession(c.env, c.req.raw);
     if (!session || session.user.isAnonymous) return c.text("Sign in to publish notes", 403);
     const { published } = await c.req.json() as { published: boolean };
-    return c.var.userStub.fetch(new Request(`https://do/notes/${c.req.param("id")}/published`, {
+    const noteId = c.req.param("id");
+
+    // When publishing, also publish any images embedded in the note so anonymous
+    // readers can load them via the public media route.
+    if (published) {
+        const noteRes = await c.var.userStub.fetch(new Request(`https://do/notes/${noteId}`));
+        if (noteRes.ok) {
+            const note = await noteRes.json() as { content?: string };
+            const ids = new Set<string>();
+            const re = /\/api\/media\/([a-f0-9-]+)\/file/gi;
+            let match: RegExpExecArray | null;
+            while ((match = re.exec(note.content || "")) !== null) ids.add(match[1]);
+            await Promise.all([...ids].map((id) =>
+                c.var.userStub.fetch(new Request(`https://do/media/${id}/published`, {
+                    method: "PATCH", headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ published: true }),
+                })).catch(() => {})
+            ));
+        }
+    }
+
+    return c.var.userStub.fetch(new Request(`https://do/notes/${noteId}/published`, {
         method: "PATCH", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ published }),
     }));

--- a/src/server/public-page.ts
+++ b/src/server/public-page.ts
@@ -11,26 +11,36 @@ function formatDate(timestamp: number): string {
     return `${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}`;
 }
 
+// Rewrite an editor image src to its publicly-servable URL. Images are stored
+// in the doc as the authed path /api/media/{id}/file (works in the editor);
+// anonymous blog readers must use the public, no-auth path instead.
+function publicImageSrc(src: string, userId: string): string {
+    const m = /^\/api\/media\/([^/]+)\/file$/.exec(src || "");
+    if (m && userId) return `/api/public/${userId}/media/${m[1]}/file`;
+    return src;
+}
+
 // Convert TipTap JSON content to HTML
 // skipFirst: omit the first node (usually the title heading) to avoid duplication
-function tiptapToHtml(content: string, skipFirst = false): string {
+// userId: owner id, used to rewrite image srcs to their public URLs
+function tiptapToHtml(content: string, skipFirst = false, userId = ""): string {
     try {
         const doc = typeof content === "string" ? JSON.parse(content) : content;
         if (!doc?.content) return "";
         const nodes = skipFirst ? doc.content.slice(1) : doc.content;
-        return renderNodes(nodes);
+        return renderNodes(nodes, userId);
     } catch {
         return escapeHtml(content || "");
     }
 }
 
-function renderNodes(nodes: any[]): string {
-    return nodes.map(renderNode).join("");
+function renderNodes(nodes: any[], userId: string): string {
+    return nodes.map((n) => renderNode(n, userId)).join("");
 }
 
-function renderNode(node: any): string {
+function renderNode(node: any, userId: string): string {
     if (!node) return "";
-    const children = node.content ? renderNodes(node.content) : "";
+    const children = node.content ? renderNodes(node.content, userId) : "";
 
     switch (node.type) {
         case "paragraph":
@@ -68,7 +78,7 @@ function renderNode(node: any): string {
         case "hardBreak":
             return "<br>";
         case "image":
-            return `<img src="${escapeHtml(node.attrs?.src || "")}" alt="${escapeHtml(node.attrs?.alt || "")}" />`;
+            return `<img src="${escapeHtml(publicImageSrc(node.attrs?.src || "", userId))}" alt="${escapeHtml(node.attrs?.alt || "")}" loading="lazy" />`;
         case "taskList":
             return `<ul class="task-list">${children}</ul>`;
         case "taskItem": {
@@ -168,10 +178,11 @@ export function renderPublicPage(profile: any, notes: any[], baseUrl: string): s
     const colorMode = profile.color_mode || "light";
     const t = THEMES[colorMode as keyof typeof THEMES] || THEMES.light;
 
+    const userId = profile.user_id || "";
     const entries = notes.map((note: any) => {
         const date = note.published_at ? formatDate(note.published_at) : "";
         const noteTitle = escapeHtml(note.title || "Untitled");
-        const html = tiptapToHtml(note.content, true);
+        const html = tiptapToHtml(note.content, true, userId);
         const folderName = note.folder_name ? escapeHtml(note.folder_name) : "";
         return `
             <article>
@@ -212,7 +223,7 @@ export function renderPublicNote(profile: any, note: any, baseUrl: string): stri
     const pageTitle = escapeHtml(profile.page_title || "My Notes");
     const noteTitle = escapeHtml(note.title || "Untitled");
     const date = note.published_at ? formatDate(note.published_at) : "";
-    const html = tiptapToHtml(note.content, true);
+    const html = tiptapToHtml(note.content, true, profile.user_id || "");
     const font = profile.font || "serif";
     const colorMode = profile.color_mode || "light";
 


### PR DESCRIPTION
Adds end-to-end inline image support to the Novel/Tiptap editor.

## What's included
- **Image node** backed by novel's `UploadImagesPlugin` (shows an upload placeholder while the file uploads, then swaps in the real `<img>`)
- **Insertion via paste, drag-and-drop, and the `/image` slash command**
- **Resize handles** via novel's `ImageResizer`
- Files upload to R2 through the existing `/api/media` endpoint; natural image dimensions are captured client-side for layout + resize hints
- On **note publish**, any embedded images are auto-published so anonymous readers can load them via the public media route
- **Public blog rendering** rewrites authed `/api/media/{id}/file` srcs to the no-auth `/api/public/{userId}/media/{id}/file` path, and adds `loading="lazy"`

## Notes
- `@tiptap/extension-image` added as a direct dependency (was already transitive via novel)
- `wrangler deploy --dry-run` passes; worker bundles and all bindings resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/97dd6695-fabc-4c95-b920-dd0526408126)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
