### PR TITLE
fix: reliability sweep — data-loss, sync races, cross-note writes, public XSS

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@tauri-apps/plugin-store": "^2.4.2",
         "@tiptap/extension-collaboration": "^2.0.0",
         "@tiptap/extension-collaboration-cursor": "^2.0.0",
+        "@tiptap/extension-image": "^2.11.2",
         "@vitejs/plugin-react": "^6.0.1",
         "better-auth": "^1.5.6",
         "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "wrangler dev --persist-to /tmp/notty-wrangler-state",
+		"dev": "wrangler dev --persist-to .wrangler-state",
 		"build": "vite build && wrangler deploy --dry-run --outdir dist",
 		"deploy": "vite build && wrangler deploy",
 		"preview": "wrangler dev",

--- a/scripts/qa-publish-race.ts
+++ b/scripts/qa-publish-race.ts
@@ -1,0 +1,125 @@
+// QA script: simulate the real "publish race" the editor hits.
+// 1. Create a note (empty, like createNote does)
+// 2. Connect Yjs over WS, type title+body (content lives only in the DO's
+//    in-memory ydoc; the 2s debounced column save has NOT fired yet)
+// 3. Publish IMMEDIATELY (inside the debounce window)
+// 4. Fetch the public page and assert the real title is rendered
+import * as Y from "yjs";
+import * as syncProtocol from "y-protocols/sync";
+import * as encoding from "lib0/encoding";
+import * as decoding from "lib0/decoding";
+
+const BASE = "http://localhost:8787";
+const COOKIE = process.env.QA_COOKIE!;
+const MSG_SYNC = 0;
+
+const h = { "Cookie": COOKIE, "Content-Type": "application/json" };
+
+async function j(path: string, init?: RequestInit) {
+    const res = await fetch(BASE + path, { ...init, headers: { ...h, ...(init?.headers || {}) } });
+    return { status: res.status, text: await res.text() };
+}
+
+// --- set profile username ---
+const prof = await j("/api/profile", { method: "POST", body: JSON.stringify({ username: "qatester", page_title: "QA Blog" }) });
+console.log("profile:", prof.status, prof.text.slice(0, 120));
+
+// --- create note (empty, as the client does) ---
+const noteId = crypto.randomUUID();
+const created = await j("/api/notes", { method: "POST", body: JSON.stringify({ id: noteId, title: "Untitled", content: "" }) });
+console.log("create:", created.status);
+
+// --- connect Yjs WS and type ---
+const doc = new Y.Doc();
+const frag = doc.getXmlFragment("default");
+
+const ws = new WebSocket(`ws://localhost:8787/api/sync?noteId=${noteId}`, { headers: { Cookie: COOKIE } } as any);
+ws.binaryType = "arraybuffer";
+
+await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = (e: any) => reject(new Error("ws error: " + (e?.message || e)));
+});
+console.log("ws: connected");
+
+ws.onmessage = (ev: MessageEvent) => {
+    const data = new Uint8Array(ev.data as ArrayBuffer);
+    const decoder = decoding.createDecoder(data);
+    const type = decoding.readVarUint(decoder);
+    if (type === MSG_SYNC) {
+        const encoder = encoding.createEncoder();
+        encoding.writeVarUint(encoder, MSG_SYNC);
+        syncProtocol.readSyncMessage(decoder, encoder, doc, null);
+        if (encoding.length(encoder) > 1) ws.send(encoding.toUint8Array(encoder));
+    }
+};
+
+// push local updates to the server as they happen (like y-websocket)
+doc.on("update", (update: Uint8Array, origin: any) => {
+    if (origin === "remote") return;
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, MSG_SYNC);
+    syncProtocol.writeUpdate(encoder, update);
+    ws.send(encoding.toUint8Array(encoder));
+});
+
+// initial sync step 1
+{
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, MSG_SYNC);
+    syncProtocol.writeSyncStep1(encoder, doc);
+    ws.send(encoding.toUint8Array(encoder));
+}
+await new Promise((r) => setTimeout(r, 500));
+
+// "type" the note: heading title + paragraph body
+doc.transact(() => {
+    const p1 = new Y.XmlElement("paragraph");
+    p1.insert(0, [new Y.XmlText("Race Condition Title")]);
+    const p2 = new Y.XmlElement("paragraph");
+    p2.insert(0, [new Y.XmlText("Body that must appear on the public page.")]);
+    frag.insert(0, [p1, p2]);
+});
+await new Promise((r) => setTimeout(r, Number(process.env.RACE_MS || 300))); // let the WS frame land, but stay inside the 2s debounce
+
+// --- publish IMMEDIATELY (the race) ---
+const pub = await j(`/api/notes/${noteId}/publish`, { method: "POST", body: JSON.stringify({ published: true }) });
+console.log("publish:", pub.status, pub.text.slice(0, 120));
+
+// --- verify: public note page (via subdomain Host header) ---
+const pubPage = await fetch(`${BASE}/${noteId}`, { headers: { Host: "qatester.notty.page" } });
+const html = await pubPage.text();
+const h2 = html.match(/<h2>([^<]*)<\/h2>/)?.[1];
+console.log("public note status:", pubPage.status, "| rendered title:", JSON.stringify(h2));
+console.log("body present:", html.includes("Body that must appear on the public page."));
+
+// --- verify: public index + RSS ---
+const idx = await (await fetch(`${BASE}/`, { headers: { Host: "qatester.notty.page" } })).text();
+console.log("index title link:", idx.match(/<h2><a[^>]*>([^<]*)<\/a><\/h2>/)?.[1]);
+const rss = await (await fetch(`${BASE}/rss`, { headers: { Host: "qatester.notty.page" } })).text();
+console.log("rss item title:", rss.match(/<item>\s*<title>([^<]*)<\/title>/)?.[1]);
+
+// --- version churn test: repeated session finalizes should coalesce ---
+for (let i = 1; i <= 4; i++) {
+    const sess = JSON.parse((await j(`/api/notes/${noteId}/sessions`, { method: "POST", body: "{}" })).text);
+    // small content change each round via HTTP save (simulates editor autosave)
+    const content = JSON.stringify({ type: "doc", content: [
+        { type: "paragraph", content: [{ type: "text", text: "Race Condition Title" }] },
+        { type: "paragraph", content: [{ type: "text", text: `Body edit round ${i}.` }] },
+    ]});
+    await j("/api/notes", { method: "POST", body: JSON.stringify({ id: noteId, title: "Race Condition Title", content }) });
+    const fin = await j(`/api/notes/${noteId}/sessions/${sess.sessionId}/finalize`, { method: "POST", body: JSON.stringify({ reason: "hidden" }) });
+    console.log(`session ${i} finalize:`, fin.status, fin.text.slice(0, 80));
+}
+const hist = JSON.parse((await j(`/api/notes/${noteId}/history`)).text);
+console.log("history count after 4 sessions:", hist.length);
+console.log("history kinds:", hist.map((v: any) => v.kind).join(","));
+
+// --- verify version content reconstructs from R2 ---
+if (hist[0]) {
+    const v = JSON.parse((await j(`/api/notes/${noteId}/history/${hist[0].id}`)).text);
+    console.log("head version title:", v.title, "| content ok:", (v.content || "").includes("Body edit round"));
+}
+
+ws.close();
+process.exit(0);

--- a/src/client/pages/note.tsx
+++ b/src/client/pages/note.tsx
@@ -443,7 +443,7 @@ export function NotePage() {
             {/* Editor */}
             <div className="max-w-4xl mx-auto px-3 sm:px-6 pt-14 sm:pt-16 pb-16 sm:pb-24">
                 <div className="bg-[var(--color-card)] border border-[var(--color-border-warm)] rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.04),0_12px_32px_rgba(0,0,0,0.03)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.3),0_12px_32px_rgba(0,0,0,0.2)] min-h-[85vh]">
-                    <Editor key={`${id}-${editorKey}`} noteId={id} shareToken={shareToken} readOnly={isViewOnly} folderId={folderId} saveGuardRef={saveGuardRef} />
+                    <Editor key={`${id}-${editorKey}`} noteId={id} shareToken={shareToken} readOnly={isViewOnly} folderId={folderId} saveGuardRef={saveGuardRef} onContentReset={handleContentReset} />
                 </div>
             </div>
 

--- a/src/client/pages/quick-note.tsx
+++ b/src/client/pages/quick-note.tsx
@@ -33,6 +33,14 @@ export function QuickNotePage() {
     const [quickNotes, setQuickNotes] = useState<Note[]>([]);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [loaded, setLoaded] = useState(false);
+    // Don't gate the editor on auth forever — after a short grace period, let
+    // the user type. Saves are local-first on desktop; auth issues surface in
+    // the main app, not by bricking the widget on "Loading...".
+    const [authGraceOver, setAuthGraceOver] = useState(false);
+    useEffect(() => {
+        const t = setTimeout(() => setAuthGraceOver(true), 3000);
+        return () => clearTimeout(t);
+    }, []);
     const quickNotesRef = useRef(quickNotes);
     quickNotesRef.current = quickNotes;
     const currentIndexRef = useRef(currentIndex);
@@ -46,7 +54,9 @@ export function QuickNotePage() {
 
     const addNewNote = useCallback(async () => {
         const id = crypto.randomUUID();
-        createNote(id, QUICK_FOLDER);
+        // Fire-and-forget is fine here (saves upsert the note anyway), but a
+        // rejection must not become an unhandled error that kills the widget.
+        createNote(id, QUICK_FOLDER).catch((e) => console.warn("[notty] Quick note create failed (will upsert on save):", e));
         const newNote: Note = {
             id,
             title: "Untitled",
@@ -60,10 +70,17 @@ export function QuickNotePage() {
     }, [createNote]);
 
     useEffect(() => {
-        loadQuickNotes().then((notes) => {
-            if (notes.length === 0) addNewNote();
-            setLoaded(true);
-        });
+        loadQuickNotes()
+            .then((notes) => {
+                if (notes.length === 0) addNewNote();
+            })
+            .catch((e) => {
+                // Don't strand the widget on "Loading..." if the DB read fails —
+                // start a fresh note so the user can still write.
+                console.warn("[notty] Failed to load quick notes:", e);
+                addNewNote();
+            })
+            .finally(() => setLoaded(true));
     }, []);
 
     // Reload quick notes from DB when window regains focus (picks up saves from cycling)
@@ -100,7 +117,7 @@ export function QuickNotePage() {
         return () => window.removeEventListener("keydown", onKeyDown);
     }, [prev, next, addNewNote, openInMain]);
 
-    if (!loaded || !user) {
+    if (!loaded || (!user && !authGraceOver)) {
         return <div className="h-screen bg-[var(--color-paper)] flex items-center justify-center text-sm text-[var(--color-ink-muted)]">Loading...</div>;
     }
 

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -26,6 +26,7 @@ import {
     CodeIcon,
 } from "lucide-react";
 import { SaveIndicator } from "./sync-status";
+import { registerNoteFlusher } from "@/lib/note-flush";
 import * as Y from "yjs";
 import Collaboration from "@tiptap/extension-collaboration";
 import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
@@ -88,7 +89,7 @@ function wait(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGuardRef, compact = false }: { noteId: string; shareToken?: string; readOnly?: boolean; folderId?: string | null; saveGuardRef?: React.MutableRefObject<boolean>; compact?: boolean }) {
+export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGuardRef, compact = false, onContentReset }: { noteId: string; shareToken?: string; readOnly?: boolean; folderId?: string | null; saveGuardRef?: React.MutableRefObject<boolean>; compact?: boolean; onContentReset?: () => void }) {
     const { saveNote } = useNotes();
     const adapter = useAdapter();
     const { user } = useAuth();
@@ -142,9 +143,22 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
     };
 
     const ydoc = useMemo(() => new Y.Doc(), [noteId]);
+    // Ref-indirected so the provider callback is stable but always calls the
+    // latest handler. When the server evicts our doc (remote restore/checkout/
+    // merge/delete → WS close 4000), suppress local saves and remount off
+    // fresh server content — otherwise the next keystroke re-uploads our stale
+    // doc and silently clobbers the reset.
+    const contentResetRef = useRef(onContentReset);
+    contentResetRef.current = onContentReset;
     const provider = useMemo(
-        () => adapter.createProvider(noteId, ydoc, { shareToken }),
-        [noteId, ydoc, adapter, shareToken]
+        () => adapter.createProvider(noteId, ydoc, {
+            shareToken,
+            onContentReset: () => {
+                if (saveGuardRef) saveGuardRef.current = true;
+                contentResetRef.current?.();
+            },
+        }),
+        [noteId, ydoc, adapter, shareToken, saveGuardRef]
     );
 
     const ensureSession = useCallback(async () => {
@@ -204,7 +218,10 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
     // Save the title + content JSON to the durable store. For shared notes,
     // Yjs WebSocket is the source of truth, so skip HTTP/local snapshot saves.
     const saveNow = useCallback((editor: EditorInstance) => {
-        if (!user || shareToken || readOnly || saveGuardRef?.current) return Promise.resolve();
+        // Desktop saves go to local SQLite and are safe without a session —
+        // never let a slow/failed auth check discard what the user typed.
+        const desktop = "__TAURI_INTERNALS__" in window;
+        if ((!user && !desktop) || shareToken || readOnly || saveGuardRef?.current || provider.reset) return Promise.resolve();
         const json = editor.getJSON();
         const text = editor.getText().trim();
         const content = JSON.stringify(json);
@@ -227,8 +244,11 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
                     scheduleMemorySync();
                     scheduleSessionIdle();
                     return;
-                } catch (e) {
-                    if (attempt === 2) {
+                } catch (e: any) {
+                    // 401 means the session died — retrying won't help. Fail fast;
+                    // assertOk already pinged the auth layer to recover, and the
+                    // next debounced save goes through once the session is back.
+                    if (e?.status === 401 || attempt === 2) {
                         setSaveState("error");
                         throw e;
                     }
@@ -354,27 +374,46 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
             return () => { cancelled = true; };
         }
 
-        // Web: show the editor as soon as local IndexedDB settles (≤150ms) — no
-        // waiting on the network. Warm revisits paint with content already in the
-        // doc; new/cold notes paint an empty editor instantly.
+        // Web: show the editor as soon as local IndexedDB settles — no waiting
+        // on the network. Warm revisits paint with content already in the doc;
+        // new/cold notes paint an empty editor instantly. Cap the wait so a
+        // hung IndexedDB can never leave the editor on "Loading..." forever.
         const persistenceReady = provider.persistence
             ? provider.persistence.whenSynced
             : Promise.resolve();
-        (compact ? persistenceReady : Promise.race([persistenceReady, new Promise((r) => setTimeout(r, 150))]))
+        Promise.race([persistenceReady, new Promise((r) => setTimeout(r, compact ? 400 : 150))])
             .then(() => { if (!cancelled) setReady(true); });
 
-        // Retroactively load the server snapshot in the background. Only seed if
-        // the doc is still empty after WS has had a chance (avoids CRDT doubling).
+        // Retroactively load the server snapshot in the background. Whether
+        // seeding it into the Yjs doc is safe depends on ONE authoritative
+        // signal — has this note ever had server-side Yjs state?
+        //  - Never initialized: the server doc is empty, seeding can't collide
+        //    with anything → seed immediately.
+        //  - Initialized: the server doc IS the source of truth. Seeding before
+        //    its state arrives is exactly the CRDT-doubling bug (two independent
+        //    insertions of the same text merge into duplicated content). So wait
+        //    for the real sync; seed only if the doc is still empty after it
+        //    (e.g. yjs_state was reset server-side). Post-sync seeding is safe.
         (async () => {
             try {
-                const data: any = await Promise.race([
+                const [data, meta] = await Promise.all([
                     adapter.getNote(noteId).catch((e) => { console.warn("[notty] HTTP bootstrap fetch failed:", e); return null; }),
-                    new Promise((r) => setTimeout(() => r(null), 1000)),
+                    adapter.getNoteMeta(noteId).catch(() => null),
                 ]);
                 if (cancelled) return;
-                const parsed = parseDoc(data?.content);
+                const parsed = parseDoc((data as any)?.content);
                 if (!parsed || hasContent()) return;
-                await Promise.race([provider.whenSynced, new Promise((r) => setTimeout(r, 800))]);
+                // Seed immediately ONLY when we can positively confirm the
+                // server doc was never initialized. If meta says it was — OR if
+                // the meta fetch failed (null) and we can't tell — wait for the
+                // real Yjs sync before seeding, so we never insert content that
+                // also arrives over the wire (the CRDT-doubling bug). Bounded so
+                // a dead socket can't strand a cold note without its content.
+                const definitelyFresh = meta !== null && !meta.yjs_initialized_at;
+                if (!definitelyFresh) {
+                    await Promise.race([provider.whenSynced, new Promise((r) => setTimeout(r, 3000))]);
+                    if (cancelled || hasContent()) return;
+                }
                 seed(parsed);
             } finally {
                 // Loading is done (content seeded, already present, or genuinely
@@ -395,6 +434,12 @@ export function Editor({ noteId, shareToken, readOnly = false, folderId, saveGua
     // Ref so unmount cleanup always calls the latest saveNow without dep churn
     const saveNowRef = useRef(saveNow);
     saveNowRef.current = saveNow;
+
+    // Let publish/share force a save instead of racing the debounce.
+    useEffect(() => registerNoteFlusher(noteId, async () => {
+        debouncedSave.cancel();
+        if (editorRef.current) await saveNowRef.current(editorRef.current);
+    }), [noteId, debouncedSave]);
 
     useEffect(() => () => {
         // On content reset (checkout/restore/merge), cancel pending saves

--- a/src/components/publish-toggle.tsx
+++ b/src/components/publish-toggle.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { Globe, GlobeLock, Copy, Check, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
 import { useAdapter } from "@/context/adapter-context";
 import { useAuth } from "@/context/auth-context";
 import { useNotes, type Note } from "@/context/notes-context";
+import { flushNote } from "@/lib/note-flush";
 import type { Profile } from "@/lib/adapter";
 
 export function PublishToggle({ noteId }: { noteId: string }) {
@@ -14,8 +16,6 @@ export function PublishToggle({ noteId }: { noteId: string }) {
     const [copied, setCopied] = useState(false);
     const [profile, setProfile] = useState<Profile | null>(null);
     const ref = useRef<HTMLDivElement>(null);
-
-    if ((user as any)?.isAnonymous) return null;
 
     const note = notes.find((n) => n.id === noteId);
     const isPublished = !!(note?.published);
@@ -37,14 +37,30 @@ export function PublishToggle({ noteId }: { noteId: string }) {
         return () => document.removeEventListener("mousedown", handler);
     }, [open]);
 
+    // Early-return AFTER all hooks — anonymous sessions flip to real users in
+    // place, and a conditional return above the hooks changes the hook count
+    // between renders (React crashes the whole note page).
+    if ((user as any)?.isAnonymous) return null;
+
     const handlePublish = async () => {
         if (isLocked) return;
         setLoading(true);
         try {
+            // Push the editor's current content to the server first so the
+            // public page can never render a stale or blank snapshot.
+            await flushNote(noteId).catch(() => {});
             await adapter.publishNote(noteId, true);
             patchNote(noteId, { published: 1, published_at: Math.floor(Date.now() / 1000) } as Partial<Note>);
+            setOpen(true);
         } catch (e: any) {
             console.error("Publish failed:", e);
+            if (e?.status === 409) {
+                toast.error("Couldn't publish — the note hasn't synced to the server yet. Check your connection and try again.");
+            } else if (e?.status === 401) {
+                toast.error("Couldn't publish — you've been signed out. Sign in and try again.");
+            } else {
+                toast.error("Couldn't publish the note. Try again in a moment.");
+            }
         } finally {
             setLoading(false);
         }

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -44,6 +44,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setAttempt((a) => a + 1);
     }, []);
 
+    // When any API call hits a 401 mid-session (expired/rotated cookie), re-run
+    // the session check so we either recover a session or show the banner —
+    // instead of the app silently failing every save while looking signed in.
+    useEffect(() => {
+        let pending = false;
+        const onExpired = () => {
+            if (pending) return;
+            pending = true;
+            setTimeout(() => { pending = false; }, 5000); // debounce bursts of 401s
+            // Re-check quietly (no loading flip — that would unmount the editor
+            // mid-typing). If the session is truly gone, show the banner.
+            (async () => {
+                try {
+                    const u = await adapter.getSession();
+                    const resolved = u ?? (await signIn().catch(() => null));
+                    setUser(resolved);
+                    setFailed(!resolved);
+                } catch {}
+            })();
+        };
+        window.addEventListener("notty:auth-expired", onExpired);
+        return () => window.removeEventListener("notty:auth-expired", onExpired);
+    }, [adapter, signIn]);
+
     useEffect(() => {
         let cancelled = false;
         (async () => {

--- a/src/context/notes-context.tsx
+++ b/src/context/notes-context.tsx
@@ -192,7 +192,12 @@ export function NotesProvider({ children }: { children: ReactNode }) {
     }, [adapter, trash]);
 
     const saveNote = useCallback(async (id: string, title: string, content: string, folderId?: string | null) => {
-        const now = Date.now();
+        // Seconds, to match the server's unixepoch() everywhere. Using ms here
+        // made every optimistic note's updated_at ~1000x larger than any server
+        // timestamp, so the fetchNotes merge (local.updated_at > server) always
+        // kept the local copy and never reconciled server truth — cross-device
+        // edits, server-derived titles, and publish state stayed invisible.
+        const now = Math.floor(Date.now() / 1000);
         const note: Note = { id, title, content, folder_id: folderId, created_at: now, updated_at: now };
 
         localEditsRef.current.set(id, note);
@@ -207,11 +212,24 @@ export function NotesProvider({ children }: { children: ReactNode }) {
             return [note, ...prev];
         });
 
-        await adapter.saveNote(id, title, content, folderId);
+        const result = await adapter.saveNote(id, title, content, folderId);
+        // Reconcile with the server's authoritative row (server timestamps,
+        // derived title) and drop the local override so future revalidations
+        // can bring in cross-device changes.
+        const saved = (result as any)?.note;
+        if (saved?.id === id) {
+            const current = localEditsRef.current.get(id);
+            // Only clear if the user hasn't typed again since this save started.
+            if (current && current.content === content && current.title === title) {
+                localEditsRef.current.delete(id);
+                setNotes((prev) => prev.map((n) => (n.id === id ? { ...n, ...saved } : n)));
+            }
+        }
     }, [adapter]);
 
     const createNote = useCallback(async (id: string, folderId?: string | null): Promise<Note> => {
-        const note: Note = { id, title: "Untitled", content: "", folder_id: folderId, created_at: Date.now(), updated_at: Date.now() };
+        const now = Math.floor(Date.now() / 1000);
+        const note: Note = { id, title: "Untitled", content: "", folder_id: folderId, created_at: now, updated_at: now };
         localEditsRef.current.set(id, note);
         setNotes((prev) => [note, ...prev]);
         await adapter.saveNote(id, "Untitled", "", folderId);
@@ -220,7 +238,7 @@ export function NotesProvider({ children }: { children: ReactNode }) {
 
     const updateNote = useCallback((id: string, data: Partial<Pick<Note, "title" | "content">>) => {
         setNotes((prev) =>
-            prev.map((n) => (n.id === id ? { ...n, ...data, updated_at: Date.now() } : n))
+            prev.map((n) => (n.id === id ? { ...n, ...data, updated_at: Math.floor(Date.now() / 1000) } : n))
         );
     }, []);
 

--- a/src/durable-objects/user-notes.ts
+++ b/src/durable-objects/user-notes.ts
@@ -3,7 +3,7 @@ import * as Y from "yjs";
 import * as syncProtocol from "y-protocols/sync";
 import * as encoding from "lib0/encoding";
 import * as decoding from "lib0/decoding";
-import { createPatch, applyPatch } from "../lib/diff";
+import { applyPatch } from "../lib/diff";
 import { deriveTitleAndPreview, isEmptyDoc } from "../lib/note-preview";
 
 const MSG_SYNC = 0;
@@ -28,7 +28,10 @@ function yNodeToTiptap(ynode: Y.XmlElement | Y.XmlText | Y.AbstractType<any>): a
 
     if (ynode instanceof Y.XmlElement) {
         const attrs = ynode.getAttributes();
-        const children = Array.from(ynode).flatMap(child => {
+        // NOTE: Y.XmlElement is NOT iterable — Array.from(ynode) yields
+        // undefineds and silently serializes every node as empty. toArray()
+        // is the real child accessor.
+        const children = ynode.toArray().flatMap(child => {
             const result = yNodeToTiptap(child);
             return Array.isArray(result) ? result : [result];
         }).filter(Boolean);
@@ -46,10 +49,12 @@ export class UserNotesDurableObject extends DurableObject {
     private sql: SqlStorage;
     private docs = new Map<string, Y.Doc>();
     private saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    private bucket: R2Bucket;
 
     constructor(ctx: DurableObjectState, env: Env) {
         super(ctx, env);
         this.sql = ctx.storage.sql;
+        this.bucket = env.MEDIA_BUCKET;
         this.ctx.blockConcurrencyWhile(async () => {
             this.sql.exec(`
                 CREATE TABLE IF NOT EXISTS notes (
@@ -107,6 +112,10 @@ export class UserNotesDurableObject extends DurableObject {
             migrate("ALTER TABLE note_versions ADD COLUMN branch_id TEXT");
             migrate("ALTER TABLE note_versions ADD COLUMN kind TEXT NOT NULL DEFAULT 'manual'");
             migrate("ALTER TABLE note_versions ADD COLUMN summary TEXT");
+            // 'sqlite' = legacy checkpoint/patch chain stored in `data`;
+            // 'r2' = full snapshot in R2, `data` holds the object key
+            migrate("ALTER TABLE note_versions ADD COLUMN storage TEXT NOT NULL DEFAULT 'sqlite'");
+            migrate("ALTER TABLE note_versions ADD COLUMN content_hash TEXT");
 
             // Branches — like git refs, just named pointers to version heads
             this.sql.exec(`
@@ -198,37 +207,65 @@ export class UserNotesDurableObject extends DurableObject {
                 }
             }
 
-            const existing = this.saveTimers.get(noteId);
-            if (existing) clearTimeout(existing);
-            this.saveTimers.set(noteId, setTimeout(() => {
-                try {
-                    const state = Y.encodeStateAsUpdate(doc!);
-                    // Also sync content + title columns so HTTP reads stay fresh
-                    const content = this.extractContentJson(noteId);
-                    if (content) {
-                        const title = deriveTitleAndPreview(content).title || "Untitled";
-                        this.sql.exec(
-                            "UPDATE notes SET yjs_state = ?, content = ?, title = ?, yjs_initialized_at = COALESCE(yjs_initialized_at, unixepoch()), pending_index = 1, updated_at = unixepoch() WHERE id = ?",
-                            state, content, title, noteId
-                        );
-                    } else {
-                        this.sql.exec(
-                            "UPDATE notes SET yjs_state = ?, yjs_initialized_at = COALESCE(yjs_initialized_at, unixepoch()), updated_at = unixepoch() WHERE id = ?",
-                            state, noteId
-                        );
-                    }
-                } catch (e) {
-                    console.error(`Failed to persist Yjs state for note ${noteId}:`, e);
-                }
-                this.saveTimers.delete(noteId);
-            }, 2000));
+            this.scheduleDocPersist(noteId, doc!, 2000);
         });
 
         this.docs.set(noteId, doc);
         return doc;
     }
 
-    private readonly CHECKPOINT_INTERVAL = 20;
+    // Persist a live Yjs doc to the notes row: yjs_state always; content +
+    // title when serialization yields a non-empty doc. Never replaces
+    // non-empty column content with an empty doc — if serialization ever
+    // regresses (or the doc is transiently blank), losing the row content is
+    // the worst outcome. Shared by the debounced save and the last-close flush
+    // so the content column can never lag behind yjs_state.
+    private persistDocNow(noteId: string, doc: Y.Doc) {
+        const state = Y.encodeStateAsUpdate(doc);
+        let content = this.extractContentJson(noteId);
+        if (content && isEmptyDoc(content)) {
+            const existing = this.sql.exec("SELECT content FROM notes WHERE id = ?", noteId).toArray()[0] as any;
+            if (existing?.content && !isEmptyDoc(existing.content)) content = null;
+        }
+        if (content) {
+            const title = deriveTitleAndPreview(content).title || "Untitled";
+            this.sql.exec(
+                "UPDATE notes SET yjs_state = ?, content = ?, title = ?, yjs_initialized_at = COALESCE(yjs_initialized_at, unixepoch()), pending_index = 1, updated_at = unixepoch() WHERE id = ?",
+                state, content, title, noteId
+            );
+        } else {
+            this.sql.exec(
+                "UPDATE notes SET yjs_state = ?, yjs_initialized_at = COALESCE(yjs_initialized_at, unixepoch()), updated_at = unixepoch() WHERE id = ?",
+                state, noteId
+            );
+        }
+    }
+
+    private scheduleDocPersist(noteId: string, doc: Y.Doc, delayMs: number, attempt = 0) {
+        const existing = this.saveTimers.get(noteId);
+        if (existing) clearTimeout(existing);
+        this.saveTimers.set(noteId, setTimeout(() => {
+            this.saveTimers.delete(noteId);
+            try {
+                this.persistDocNow(noteId, doc);
+            } catch (e) {
+                console.error(`Failed to persist Yjs state for note ${noteId} (attempt ${attempt + 1}):`, e);
+                // Don't drop the only copy of the user's edits on a transient
+                // failure — re-arm with backoff. The in-memory doc is the sole
+                // holder of this content until a persist succeeds.
+                if (attempt < 5) this.scheduleDocPersist(noteId, doc, Math.min(2000 * 2 ** attempt, 30000), attempt + 1);
+            }
+        }, delayMs));
+    }
+
+    // Consecutive autosave-session versions inside this window are amended in
+    // place instead of appended, so tab-switch/idle churn doesn't flood history.
+    private readonly SESSION_AMEND_WINDOW_S = 15 * 60;
+    private readonly MAX_VERSIONS_PER_NOTE = 1000;
+
+    private versionKey(noteId: string, versionId: string): string {
+        return `versions/${this.ctx.id.toString()}/${noteId}/${versionId}.json`;
+    }
 
     // --- Branch helpers ---
 
@@ -261,11 +298,17 @@ export class UserNotesDurableObject extends DurableObject {
 
     // --- Version creation (branch-aware) ---
 
-    private createVersion(noteId: string, title: string, content: string, createdBy = "system", kind = "manual", summary: string | null = null): string | null {
+    private async createVersion(noteId: string, title: string, content: string, createdBy = "system", kind = "manual", summary: string | null = null): Promise<string | null> {
         const branch = this.getCurrentBranch(noteId);
         const parentId = branch.head_version_id;
+        const hash = this.contentHash(content);
 
-        const id = crypto.randomUUID();
+        const head = parentId ? this.sql.exec(
+            "SELECT id, kind, storage, data, content_hash, created_at FROM note_versions WHERE id = ?", parentId
+        ).toArray()[0] as any : null;
+
+        // Identical to head → nothing to record
+        if (head?.content_hash && head.content_hash === hash) return null;
 
         // Defense-in-depth: never record an accidental wipe as a version. A
         // transient empty doc (load race, reconnect, stale beacon) snapshotted
@@ -273,49 +316,89 @@ export class UserNotesDurableObject extends DurableObject {
         // diffs. If the new content is blank but the previous version had text,
         // skip — the client-side guard should already prevent this, but old
         // clients and the unmount beacon can still slip an empty doc through.
-        if (parentId && isEmptyDoc(content) && !isEmptyDoc(this.reconstructVersion(parentId, noteId))) {
-            return null;
+        // Fail closed: if we can't read the previous version (R2 blip), don't
+        // record the empty doc either.
+        if (head && isEmptyDoc(content)) {
+            let prevContent: string;
+            try {
+                prevContent = await this.reconstructVersion(head.id, noteId, { strict: true });
+            } catch {
+                return null;
+            }
+            if (!isEmptyDoc(prevContent)) return null;
         }
 
-        // Count versions on this branch since last checkpoint
-        let sinceCheckpoint = 0;
-        if (parentId) {
-            const count = this.sql.exec(
-                `SELECT COUNT(*) as c FROM note_versions
-                 WHERE branch_id = ? AND created_at >= COALESCE(
-                     (SELECT created_at FROM note_versions WHERE branch_id = ? AND is_checkpoint = 1 ORDER BY created_at DESC LIMIT 1),
-                     0
-                 )`, branch.id, branch.id
-            ).toArray()[0] as { c: number };
-            sinceCheckpoint = count?.c ?? 0;
-        }
-
-        const needsCheckpoint = !parentId || sinceCheckpoint >= this.CHECKPOINT_INTERVAL;
-
-        if (needsCheckpoint) {
+        // Coalesce autosave churn: a session version right after another
+        // session version just moves that version forward instead of stacking
+        // a new entry per tab-switch/idle. Never amend a version that another
+        // branch also points at (branch create copies head_version_id) — that
+        // would silently rewrite the other branch's snapshot in place.
+        const now = Math.floor(Date.now() / 1000);
+        const headSharedWithOtherBranch = head ? this.sql.exec(
+            "SELECT 1 FROM note_branches WHERE head_version_id = ? AND id != ? LIMIT 1", head.id, branch.id
+        ).toArray().length > 0 : false;
+        if (
+            kind === "session" && head?.kind === "session" && head.storage === "r2" &&
+            !headSharedWithOtherBranch &&
+            now - head.created_at < this.SESSION_AMEND_WINDOW_S
+        ) {
+            await this.bucket.put(head.data, content, { httpMetadata: { contentType: "application/json" } });
             this.sql.exec(
-                "INSERT INTO note_versions (id, note_id, parent_id, branch_id, title, is_checkpoint, data, created_by, kind, summary) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)",
-                id, noteId, parentId, branch.id, title, content, createdBy, kind, summary
+                "UPDATE note_versions SET title = ?, summary = ?, content_hash = ?, created_at = unixepoch() WHERE id = ?",
+                title, summary, hash, head.id
             );
-        } else {
-            const parentContent = this.reconstructVersion(parentId!, noteId);
-            const patch = createPatch(parentContent, content);
-            if (patch === '[]') return null;
-            this.sql.exec(
-                "INSERT INTO note_versions (id, note_id, parent_id, branch_id, title, is_checkpoint, data, created_by, kind, summary) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?)",
-                id, noteId, parentId, branch.id, title, patch, createdBy, kind, summary
-            );
+            return head.id;
         }
+
+        const id = crypto.randomUUID();
+        const key = this.versionKey(noteId, id);
+        await this.bucket.put(key, content, { httpMetadata: { contentType: "application/json" } });
+        this.sql.exec(
+            "INSERT INTO note_versions (id, note_id, parent_id, branch_id, title, is_checkpoint, data, created_by, kind, summary, storage, content_hash) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, 'r2', ?)",
+            id, noteId, parentId, branch.id, title, key, createdBy, kind, summary, hash
+        );
 
         this.sql.exec("UPDATE note_branches SET head_version_id = ? WHERE id = ?", id, branch.id);
 
-        this.sql.exec(`
-            DELETE FROM note_versions WHERE note_id = ? AND id NOT IN (
-                SELECT id FROM note_versions WHERE note_id = ? ORDER BY created_at DESC LIMIT 1000
-            )
-        `, noteId, noteId);
-
+        await this.pruneVersions(noteId);
         return id;
+    }
+
+    private async pruneVersions(noteId: string) {
+        const stale = this.sql.exec(
+            `SELECT id, data, storage FROM note_versions WHERE note_id = ? AND id NOT IN (
+                SELECT id FROM note_versions WHERE note_id = ? ORDER BY created_at DESC LIMIT ${this.MAX_VERSIONS_PER_NOTE}
+            )`, noteId, noteId
+        ).toArray() as any[];
+        if (stale.length === 0) return;
+        for (let i = 0; i < stale.length; i += 500) {
+            const batch = stale.slice(i, i + 500);
+            this.sql.exec(
+                `DELETE FROM note_versions WHERE id IN (${batch.map(() => "?").join(",")})`,
+                ...batch.map((r) => r.id)
+            );
+            const keys = batch.filter((r) => r.storage === "r2").map((r) => r.data as string);
+            if (keys.length > 0) {
+                try { await this.bucket.delete(keys); } catch (e) {
+                    console.error(`Failed to delete pruned version objects for note ${noteId}:`, e);
+                }
+            }
+        }
+    }
+
+    // Delete all version data (rows + R2 objects) for a note. Used on permanent delete.
+    private async deleteAllVersions(noteId: string) {
+        const rows = this.sql.exec(
+            "SELECT data FROM note_versions WHERE note_id = ? AND storage = 'r2'", noteId
+        ).toArray() as any[];
+        this.sql.exec("DELETE FROM note_versions WHERE note_id = ?", noteId);
+        this.sql.exec("DELETE FROM note_branches WHERE note_id = ?", noteId);
+        for (let i = 0; i < rows.length; i += 1000) {
+            const keys = rows.slice(i, i + 1000).map((r) => r.data as string);
+            try { await this.bucket.delete(keys); } catch (e) {
+                console.error(`Failed to delete version objects for note ${noteId}:`, e);
+            }
+        }
     }
 
     private contentHash(content: string): string {
@@ -338,7 +421,7 @@ export class UserNotesDurableObject extends DurableObject {
         return { sessionId };
     }
 
-    private finalizeEditSession(noteId: string, sessionId: string, reason = "finalize"): { versionId?: string } {
+    private async finalizeEditSession(noteId: string, sessionId: string, reason = "finalize"): Promise<{ versionId?: string }> {
         const session = this.sql.exec(
             "SELECT id, base_content FROM edit_sessions WHERE id = ? AND note_id = ? AND finalized_at IS NULL",
             sessionId, noteId
@@ -350,9 +433,9 @@ export class UserNotesDurableObject extends DurableObject {
         this.sql.exec("UPDATE edit_sessions SET finalized_at = unixepoch(), last_edit_at = unixepoch() WHERE id = ?", sessionId);
         if (!note || currentContent === (session.base_content || "")) return {};
 
-        const versionId = this.createVersion(
+        const versionId = await this.createVersion(
             noteId,
-            note.title || "Untitled",
+            deriveTitleAndPreview(currentContent).title || (note.title as string) || "Untitled",
             currentContent,
             "session",
             "session",
@@ -365,15 +448,33 @@ export class UserNotesDurableObject extends DurableObject {
         return { versionId };
     }
 
-    private reconstructVersion(versionId: string, noteId: string): string {
+    // strict: throw on R2 read errors instead of degrading to "" — used where
+    // the caller must distinguish "genuinely empty" from "couldn't read".
+    private async reconstructVersion(versionId: string, noteId: string, opts?: { strict?: boolean }): Promise<string> {
+        // New-style versions are full snapshots in R2
+        const head = this.sql.exec(
+            "SELECT storage, data FROM note_versions WHERE id = ?", versionId
+        ).toArray()[0] as any;
+        if (head?.storage === "r2") {
+            try {
+                const obj = await this.bucket.get(head.data);
+                if (obj) return await obj.text();
+            } catch (e) {
+                console.error(`Failed to read version object ${head.data}:`, e);
+                if (opts?.strict) throw e;
+            }
+            return "";
+        }
+
+        // Legacy versions: walk the checkpoint + patch chain in SQLite
         const chain: { id: string; data: string; is_checkpoint: number; parent_id: string | null }[] = [];
         let currentId: string | null = versionId;
 
         while (currentId) {
             const row = this.sql.exec(
-                "SELECT id, data, is_checkpoint, parent_id FROM note_versions WHERE id = ?", currentId
+                "SELECT id, data, is_checkpoint, parent_id, storage FROM note_versions WHERE id = ?", currentId
             ).toArray()[0] as any;
-            if (!row) break;
+            if (!row || row.storage === "r2") break;
             chain.unshift(row);
             if (row.is_checkpoint) break;
             currentId = row.parent_id;
@@ -415,8 +516,16 @@ export class UserNotesDurableObject extends DurableObject {
         this.saveTimers.delete(noteId);
         const doc = this.docs.get(noteId);
         if (!doc) return;
-        const state = Y.encodeStateAsUpdate(doc);
-        this.sql.exec("UPDATE notes SET yjs_state = ?, updated_at = unixepoch() WHERE id = ?", state, noteId);
+        // Full persist (yjs_state + content + title), not just yjs_state —
+        // otherwise the content column lags the final typing burst, and
+        // anything that snapshots or backs up from the column (restore,
+        // checkout, session finalize) captures stale content while
+        // yjs_state gets nulled — permanently losing the burst.
+        try {
+            this.persistDocNow(noteId, doc);
+        } catch (e) {
+            console.error(`Failed to flush pending save for note ${noteId}:`, e);
+        }
     }
 
     async fetch(request: Request): Promise<Response> {
@@ -508,6 +617,10 @@ export class UserNotesDurableObject extends DurableObject {
                         body.sync_mode !== undefined ? body.sync_mode : existing.sync_mode,
                         id
                     );
+                    // Also evict the cached in-memory doc — it still holds the
+                    // OLD Yjs state, and the next WS connect would serve it and
+                    // then persist it right back over this newer content.
+                    this.resetNoteSync(id);
                 }
             } else {
                 this.sql.exec(
@@ -521,8 +634,12 @@ export class UserNotesDurableObject extends DurableObject {
         }
         if (request.method === "DELETE" && path.startsWith("/notes/") && !path.includes("/", "/notes/".length)) {
             const id = path.slice("/notes/".length);
-            this.sql.exec("UPDATE notes SET deleted_at = unixepoch() WHERE id = ?", id);
-            this.docs.delete(id);
+            // Unpublish on trash — a trashed note must not stay readable at
+            // its public URL. Flush pending edits first so restore-from-trash
+            // recovers everything the user typed.
+            this.flushPendingSave(id);
+            this.sql.exec("UPDATE notes SET deleted_at = unixepoch(), published = 0 WHERE id = ?", id);
+            this.resetNoteSync(id);
             this.broadcastJson({ type: "note-deleted", id });
             return new Response("OK");
         }
@@ -538,7 +655,11 @@ export class UserNotesDurableObject extends DurableObject {
         if (request.method === "DELETE" && path.match(/^\/notes\/[^/]+\/permanent$/)) {
             const id = path.split("/")[2];
             this.sql.exec("DELETE FROM notes WHERE id = ?", id);
-            this.docs.delete(id);
+            // Full reset (not just docs.delete): kills the pending save timer
+            // (which would otherwise resurrect a cached doc) and closes any
+            // open sockets still accepting edits into the void.
+            this.resetNoteSync(id);
+            await this.deleteAllVersions(id);
             return Response.json({ ok: true });
         }
 
@@ -568,11 +689,19 @@ export class UserNotesDurableObject extends DurableObject {
             if (published) {
                 const note = this.getNote(id);
                 if (note?.locked) return new Response("Cannot publish a locked note", { status: 400 });
-                // Sync Yjs content to the content column so public pages have fresh data
-                const content = this.extractContentJson(id);
-                if (content) {
-                    this.sql.exec("UPDATE notes SET content = ? WHERE id = ?", content, id);
+                // Sync Yjs content AND title so the public page never renders a
+                // stale "Untitled" — the debounced Yjs save may not have fired yet
+                // when the user hits publish right after typing.
+                const content = this.extractContentJson(id) || (note?.content as string) || "";
+                // Refuse to publish a blank page. If neither the live Yjs doc nor
+                // the content column has text, the note hasn't reached the server
+                // (dead session, offline, sync failure) — publishing would ship an
+                // empty public page. Tell the client instead.
+                if (isEmptyDoc(content)) {
+                    return new Response("Note content hasn't synced to the server yet", { status: 409 });
                 }
+                const title = deriveTitleAndPreview(content).title || (note?.title as string) || "Untitled";
+                this.sql.exec("UPDATE notes SET content = ?, title = ? WHERE id = ?", content, title, id);
             }
             this.sql.exec(
                 `UPDATE notes SET published = ?, published_at = CASE WHEN ? THEN unixepoch() ELSE published_at END, updated_at = unixepoch() WHERE id = ?`,
@@ -601,7 +730,7 @@ export class UserNotesDurableObject extends DurableObject {
             const noteId = parts[2];
             const sessionId = parts[4];
             const body = await request.json().catch(() => ({})) as { reason?: string };
-            return Response.json(this.finalizeEditSession(noteId, sessionId, body.reason || "finalize"));
+            return Response.json(await this.finalizeEditSession(noteId, sessionId, body.reason || "finalize"));
         }
 
         if (request.method === "POST" && path.match(/^\/notes\/[^/]+\/memory-indexed$/)) {
@@ -662,20 +791,27 @@ export class UserNotesDurableObject extends DurableObject {
             ).toArray()[0] as any;
             if (!branch) return new Response("Branch not found", { status: 404 });
 
-            // Version the current state before switching (so no work is lost)
+            // Load branch HEAD content FIRST — strict, so an R2 blip aborts
+            // the checkout instead of silently writing "" over the live note.
+            let content = "";
+            if (branch.head_version_id) {
+                try {
+                    content = await this.reconstructVersion(branch.head_version_id, noteId, { strict: true });
+                } catch {
+                    return new Response("Could not load branch content, try again", { status: 503 });
+                }
+            }
+
+            // Version the current state before switching (so no work is lost).
+            // Flush first so the content column includes the final typing burst.
+            this.flushPendingSave(noteId);
             const currentNote = this.getNote(noteId);
             if (currentNote?.content) {
-                this.createVersion(noteId, currentNote.title || "Untitled", currentNote.content as string, "auto-backup", "backup", "Auto-backup before branch checkout");
+                await this.createVersion(noteId, (currentNote.title as string) || "Untitled", currentNote.content as string, "auto-backup", "backup", "Auto-backup before branch checkout");
             }
 
             // Switch current branch
             this.sql.exec("UPDATE notes SET current_branch_id = ?, updated_at = unixepoch() WHERE id = ?", branch_id, noteId);
-
-            // Load branch HEAD content
-            let content = "";
-            if (branch.head_version_id) {
-                content = this.reconstructVersion(branch.head_version_id, noteId);
-            }
 
             this.sql.exec(
                 "UPDATE notes SET content = ?, yjs_state = NULL, updated_at = unixepoch() WHERE id = ?",
@@ -720,10 +856,24 @@ export class UserNotesDurableObject extends DurableObject {
             const current = this.getCurrentBranch(noteId);
             if (current.id === source.id) return new Response("Cannot merge branch into itself", { status: 400 });
 
-            const sourceContent = this.reconstructVersion(source.head_version_id, noteId);
+            // Strict read — an R2 blip must abort the merge, not blank the note.
+            let sourceContent: string;
+            try {
+                sourceContent = await this.reconstructVersion(source.head_version_id, noteId, { strict: true });
+            } catch {
+                return new Response("Could not load source branch content, try again", { status: 503 });
+            }
+
+            // Back up the current state first (checkout and restore do this;
+            // merge previously overwrote the live note with no recovery path).
+            this.flushPendingSave(noteId);
+            const beforeMerge = this.getNote(noteId);
+            if (beforeMerge?.content) {
+                await this.createVersion(noteId, (beforeMerge.title as string) || "Untitled", beforeMerge.content as string, "auto-backup", "backup", "Auto-backup before merge");
+            }
 
             // Create a merge version on the current branch
-            this.createVersion(noteId, `Merge ${source.name}`, sourceContent, "merge", "merge", `Merged ${source.name}`);
+            await this.createVersion(noteId, `Merge ${source.name}`, sourceContent, "merge", "merge", `Merged ${source.name}`);
 
             this.sql.exec(
                 "UPDATE notes SET content = ?, yjs_state = NULL, updated_at = unixepoch() WHERE id = ?",
@@ -774,7 +924,7 @@ export class UserNotesDurableObject extends DurableObject {
                 versionId, noteId
             ).toArray()[0];
             if (!row) return new Response("Version not found", { status: 404 });
-            const content = this.reconstructVersion(versionId, noteId);
+            const content = await this.reconstructVersion(versionId, noteId);
             return Response.json({ ...row, content });
         }
         // Restore to a specific version
@@ -786,12 +936,12 @@ export class UserNotesDurableObject extends DurableObject {
             ).toArray()[0];
             if (!row) return new Response("Version not found", { status: 404 });
 
-            const restoredContent = this.reconstructVersion(version_id, noteId);
+            const restoredContent = await this.reconstructVersion(version_id, noteId);
 
             // Version the current state before restoring (so restore itself is reversible)
             const current = this.getNote(noteId);
             if (current?.content) {
-                this.createVersion(noteId, current.title || "Untitled", current.content as string, "auto-backup", "backup", "Auto-backup before restore");
+                await this.createVersion(noteId, (current.title as string) || "Untitled", current.content as string, "auto-backup", "backup", "Auto-backup before restore");
             }
 
             // Apply the restored content
@@ -804,7 +954,7 @@ export class UserNotesDurableObject extends DurableObject {
                 restoredTitle, restoredContent, noteId
             );
 
-            this.createVersion(noteId, restoredTitle, restoredContent, "restore", "restore", "Restored version");
+            await this.createVersion(noteId, restoredTitle, restoredContent, "restore", "restore", "Restored version");
             this.resetNoteSync(noteId);
 
             const note = this.getNote(noteId);
@@ -818,7 +968,13 @@ export class UserNotesDurableObject extends DurableObject {
                  FROM notes n LEFT JOIN folders f ON n.folder_id = f.id
                  WHERE n.published = 1 AND n.deleted_at IS NULL ORDER BY n.published_at DESC`
             ).toArray();
-            return Response.json(rows);
+            // Derive the title from content when the stored column is stale —
+            // the public page and RSS should never show "Untitled" for a note
+            // that has real text.
+            return Response.json(rows.map((row: any) => ({
+                ...row,
+                title: (row.title && row.title !== "Untitled") ? row.title : deriveTitleAndPreview(row.content).title || row.title || "Untitled",
+            })));
         }
 
         // --- Media routes ---
@@ -923,6 +1079,11 @@ export class UserNotesDurableObject extends DurableObject {
 
             if (msg.type === "save-note") {
                 const { id, title, content } = msg;
+                // The socket was authorized for exactly one note (its first
+                // tag). Without this check, any edit-share visitor could
+                // upsert ARBITRARY notes in the owner's DO by sending a
+                // save-note with a different id.
+                if (id !== this.ctx.getTags(ws)[0]) return;
                 this.sql.exec(
                     `INSERT INTO notes (id, title, content, pending_index, updated_at) VALUES (?, ?, ?, 1, unixepoch())
                      ON CONFLICT(id) DO UPDATE SET title = excluded.title, content = excluded.content, pending_index = 1, updated_at = unixepoch()`,
@@ -1011,7 +1172,7 @@ export class UserNotesDurableObject extends DurableObject {
 
     private getNote(id: string) {
         const rows = this.sql
-            .exec("SELECT id, title, content, folder_id, sync_mode, locked, published, published_at, current_branch_id, created_at, updated_at FROM notes WHERE id = ?", id)
+            .exec("SELECT id, title, content, folder_id, sync_mode, locked, published, published_at, deleted_at, current_branch_id, created_at, updated_at FROM notes WHERE id = ?", id)
             .toArray();
         return rows[0] || null;
     }
@@ -1022,7 +1183,12 @@ export class UserNotesDurableObject extends DurableObject {
             const doc = this.getYDoc(noteId);
             const fragment = doc.getXmlFragment("default");
             if (fragment.length === 0) return null;
-            const json = { type: "doc", content: Array.from(fragment).map(yNodeToTiptap).flat().filter(Boolean) };
+            // toArray(), NOT Array.from() — Y.XmlFragment isn't iterable, and
+            // Array.from used to produce [undefined, ...], which serialized
+            // every note to {"type":"doc","content":[]} and then OVERWROTE the
+            // real content column with it on the debounced save. This was the
+            // "published note is completely blank / Untitled" bug.
+            const json = { type: "doc", content: fragment.toArray().map(yNodeToTiptap).flat().filter(Boolean) };
             return JSON.stringify(json);
         } catch {
             return null;
@@ -1032,9 +1198,14 @@ export class UserNotesDurableObject extends DurableObject {
     private broadcastJson(message: object, exclude?: WebSocket) {
         const data = JSON.stringify(message);
         for (const ws of this.ctx.getWebSockets()) {
-            if (ws !== exclude) {
-                try { ws.send(data); } catch { ws.close(); }
-            }
+            if (ws === exclude) continue;
+            // note-updated/media events carry full note content and are meant
+            // for the owner's other tabs. Shared-note visitors (perm:view/edit
+            // on ONE note) must not receive the owner's other notes.
+            const tags = this.ctx.getTags(ws);
+            const perm = tags.find((t) => t.startsWith("perm:"));
+            if (perm && perm !== "perm:owner") continue;
+            try { ws.send(data); } catch { ws.close(); }
         }
     }
 }

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -189,5 +189,5 @@ export interface NottyAdapter {
     updateProfile(data: Partial<Profile>): Promise<void>;
 
     // Realtime
-    createProvider(noteId: string, doc: Y.Doc, opts?: { shareToken?: string }): NottyProvider;
+    createProvider(noteId: string, doc: Y.Doc, opts?: { shareToken?: string; onContentReset?: () => void }): NottyProvider;
 }

--- a/src/lib/note-flush.ts
+++ b/src/lib/note-flush.ts
@@ -1,0 +1,18 @@
+// Registry of open editors' flush functions. Lets actions that depend on the
+// server having the latest content (publish, share) force a save first instead
+// of racing the debounced autosave.
+
+const flushers = new Map<string, () => Promise<void>>();
+
+export function registerNoteFlusher(noteId: string, flush: () => Promise<void>) {
+    flushers.set(noteId, flush);
+    return () => {
+        if (flushers.get(noteId) === flush) flushers.delete(noteId);
+    };
+}
+
+/** Flush the open editor for a note, if any. Resolves even if no editor is open. */
+export async function flushNote(noteId: string): Promise<void> {
+    const flush = flushers.get(noteId);
+    if (flush) await flush();
+}

--- a/src/lib/web-adapter.ts
+++ b/src/lib/web-adapter.ts
@@ -4,7 +4,16 @@ import { NottyProvider } from "./yjs-provider";
 import { authClient } from "./auth-client";
 
 async function assertOk(res: Response, context: string) {
-    if (!res.ok) throw new Error(`${context}: ${res.status} ${res.statusText}`);
+    if (!res.ok) {
+        // A 401 mid-session means the session cookie died under us. Tell the
+        // auth layer to recover instead of letting every save silently loop.
+        if (res.status === 401) {
+            try { window.dispatchEvent(new CustomEvent("notty:auth-expired")); } catch {}
+        }
+        const err = new Error(`${context}: ${res.status} ${res.statusText}`);
+        (err as any).status = res.status;
+        throw err;
+    }
 }
 
 // IndexedDB-backed cache for the notes list so the PWA works offline
@@ -446,7 +455,7 @@ export class WebAdapter implements NottyAdapter {
         await assertOk(res, "Failed to update profile");
     }
 
-    createProvider(noteId: string, doc: Y.Doc, opts?: { shareToken?: string }): NottyProvider {
-        return new NottyProvider(noteId, doc, { connect: false, shareToken: opts?.shareToken });
+    createProvider(noteId: string, doc: Y.Doc, opts?: { shareToken?: string; onContentReset?: () => void }): NottyProvider {
+        return new NottyProvider(noteId, doc, { connect: false, shareToken: opts?.shareToken, onContentReset: opts?.onContentReset });
     }
 }

--- a/src/lib/yjs-provider.ts
+++ b/src/lib/yjs-provider.ts
@@ -19,23 +19,30 @@ export class NottyProvider {
     private pendingUpdates: Uint8Array[] = [];
     private serverUrl: string | null = null;
     private reconnectDelay = 1000;
+    private failedConnects = 0;
     private syncResolve: (() => void) | null = null;
     readonly whenSynced: Promise<void>;
 
     private shareToken: string | undefined;
     private authToken: string | undefined;
     private offlineOnly: boolean;
+    private onContentReset: (() => void) | undefined;
+    // Set once the server evicts this doc (close 4000). The local doc is now
+    // stale relative to the server; no more sends, and the editor must remount
+    // off fresh server state instead of pushing this doc's history back.
+    reset = false;
 
     constructor(
         private noteId: string,
         doc: Y.Doc,
-        options?: { connect?: boolean; shareToken?: string; token?: string; skipPersistence?: boolean }
+        options?: { connect?: boolean; shareToken?: string; token?: string; skipPersistence?: boolean; onContentReset?: () => void }
     ) {
         this.doc = doc;
         this.awareness = new awarenessProtocol.Awareness(doc);
         this.offlineOnly = options?.connect === false;
         this.shareToken = options?.shareToken;
         this.authToken = options?.token;
+        this.onContentReset = options?.onContentReset;
         this.whenSynced = new Promise(resolve => { this.syncResolve = resolve; });
 
         // Skip persistence for shared notes and desktop (which uses local SQLite)
@@ -44,7 +51,7 @@ export class NottyProvider {
             : new IndexeddbPersistence(`notty-${noteId}`, doc);
 
         this.doc.on("update", (update: Uint8Array, origin: any) => {
-            if (origin === this) return;
+            if (origin === this || this.reset) return;
             if (this.connected) {
                 this.sendUpdate(update);
             } else {
@@ -94,6 +101,7 @@ export class NottyProvider {
         ws.onopen = () => {
             this.connected = true;
             this.reconnectDelay = 1000;
+            this.failedConnects = 0;
 
             // Sync step 1 — tells server what we have, server sends what we're missing
             const encoder = encoding.createEncoder();
@@ -101,11 +109,14 @@ export class NottyProvider {
             syncProtocol.writeSyncStep1(encoder, this.doc);
             ws.send(encoding.toUint8Array(encoder));
 
-            // Flush any updates queued while offline
-            for (const update of this.pendingUpdates) {
+            // Flush any updates queued while offline. Swap the array first —
+            // if the socket dies mid-flush, sendUpdate re-queues into the new
+            // array instead of being cleared away below.
+            const queued = this.pendingUpdates;
+            this.pendingUpdates = [];
+            for (const update of queued) {
                 this.sendUpdate(update);
             }
-            this.pendingUpdates = [];
 
             // Send awareness
             if (this.awareness.getLocalState() !== null) {
@@ -144,12 +155,33 @@ export class NottyProvider {
         };
 
         ws.onclose = (event) => {
+            const wasConnected = this.connected;
             this.ws = null;
             this.connected = false;
-            if (!this.destroyed && event.code !== 4000) {
-                this.reconnectDelay = Math.min((this.reconnectDelay || 1000) * 2, 30000);
-                setTimeout(() => this.connect(), this.reconnectDelay);
+            if (this.destroyed) return;
+            if (event.code === 4000) {
+                // Server reset this note's content (restore/checkout/merge/
+                // delete on another client). Our doc is now stale — stop all
+                // sends and tell the editor to remount off fresh server state.
+                // Without this, the next keystroke would push this stale doc's
+                // full history back and clobber the reset.
+                this.reset = true;
+                this.pendingUpdates = [];
+                try { this.onContentReset?.(); } catch {}
+                return;
             }
+            if (!wasConnected) {
+                // Connection refused before opening — with a dead session the
+                // server 401s the upgrade and this loops forever in silence.
+                // After a few failures, ask the auth layer to recover the
+                // session; keep backing off and retrying regardless.
+                this.failedConnects++;
+                if (this.failedConnects === 3) {
+                    try { window.dispatchEvent(new CustomEvent("notty:auth-expired")); } catch {}
+                }
+            }
+            this.reconnectDelay = Math.min((this.reconnectDelay || 1000) * 2, 30000);
+            setTimeout(() => this.connect(), this.reconnectDelay);
         };
 
         ws.onerror = () => {
@@ -160,7 +192,12 @@ export class NottyProvider {
     }
 
     private sendUpdate(update: Uint8Array) {
-        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            // Socket mid-close/opening — queue instead of dropping so the edit
+            // reaches the server on reconnect even before syncStep1 completes.
+            this.pendingUpdates.push(update);
+            return;
+        }
         const encoder = encoding.createEncoder();
         encoding.writeVarUint(encoder, MSG_SYNC);
         syncProtocol.writeUpdate(encoder, update);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,7 @@ loadEnv();
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { renderPublicPage, renderPublicNote } from "./public-page";
+import { renderPublicPage, renderPublicNote, publicNoteTitle } from "./public-page";
 import { renderRSS } from "./rss";
 import { generateOgImage } from "./og-image";
 import {
@@ -52,6 +52,14 @@ app.get("*", async (c, next) => {
 
     const path = new URL(c.req.url).pathname;
 
+    // Let API + asset routes through — the public media path
+    // (/api/public/:userId/media/...) that inline blog images point at lives
+    // on the same subdomain and would otherwise 404 in the note branch below,
+    // breaking every image on published pages.
+    if (path.startsWith("/api/") || path.startsWith("/assets/") || path === "/favicon.ico" || path === "/robots.txt") {
+        return next();
+    }
+
     // Resolve username → userId
     const authStub = c.env.AUTH_DO.get(c.env.AUTH_DO.idFromName("auth-singleton"));
     const profileRes = await authStub.fetch(new Request(`https://do/internal/profile/by-username?username=${encodeURIComponent(username)}`));
@@ -80,7 +88,9 @@ app.get("*", async (c, next) => {
         const noteRes = await userStub.fetch(new Request(`https://do/notes/${noteId}`));
         if (!noteRes.ok) return c.text("Not found", 404);
         const note = await noteRes.json() as any;
-        if (!note.published) return c.text("Not found", 404);
+        // A trashed note must not stay readable at its public URL, even if it
+        // was published before being trashed.
+        if (!note.published || note.deleted_at) return c.text("Not found", 404);
         const baseUrl = `https://${username}.${c.env.BASE_DOMAIN || "notty.page"}`;
         return c.html(renderPublicNote(profile, note, baseUrl));
     }
@@ -332,14 +342,20 @@ app.get("/api/notes/:id", async (c) => {
 });
 
 app.put("/api/notes/:id", async (c) => {
-    const body = await c.req.text();
+    const raw = await c.req.text();
     const id = c.req.param("id");
     const shareToken = c.req.query("share");
     const access = await resolveNoteAccess(c.env, id, c.var.userId, shareToken);
     if (!access) return c.text("Not found", 404);
     if (access.permission === "view") return c.text("Read only", 403);
+    // Pin the body's id to the authorized URL param. Otherwise a share-edit
+    // user authorized for note X could send {id: Y, ...} and overwrite an
+    // arbitrary note Y in the owner's DO.
+    let parsed: any = {};
+    try { parsed = raw ? JSON.parse(raw) : {}; } catch { return c.text("Bad request", 400); }
+    parsed.id = id;
     const doRes = await access.stub.fetch(new Request("https://do/notes", {
-        method: "POST", headers: { "Content-Type": "application/json" }, body,
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(parsed),
     }));
 
     return doRes;
@@ -671,7 +687,7 @@ app.get("/api/shared/:token/og-image.png", async (c) => {
     const note = await noteRes.json() as any;
 
     const origin = new URL(c.req.url).origin;
-    const png = await generateOgImage(note.title || "Untitled", note.content || "", `${origin}/logo.png`);
+    const png = await generateOgImage(publicNoteTitle(note), note.content || "", `${origin}/logo.png`);
     return c.body(png as any, 200, {
         "Content-Type": "image/png",
         "Cache-Control": "public, max-age=3600",
@@ -697,14 +713,7 @@ app.get("/api/shared/:token", async (c) => {
     let title = "Shared Note";
     if (noteRes.ok) {
         const note = await noteRes.json() as any;
-        title = note.title || "Untitled";
-        if (title === "Untitled" && note.content) {
-            try {
-                const doc = JSON.parse(note.content);
-                const first = doc?.content?.[0]?.content?.map((n: any) => n.text || "").join("").trim();
-                if (first) title = first;
-            } catch {}
-        }
+        title = publicNoteTitle(note);
     }
 
     const origin = new URL(c.req.url).origin;

--- a/src/server/public-page.ts
+++ b/src/server/public-page.ts
@@ -1,7 +1,26 @@
 // Server-side HTML rendering for public pages — no React, no JS needed for readers
 
+import { deriveTitleAndPreview } from "../lib/note-preview";
+
+// Last line of defense against publishing a stale "Untitled": prefer the stored
+// title, but if it's missing/default, derive it from the note content itself.
+export function publicNoteTitle(note: { title?: string; content?: string }): string {
+    if (note.title && note.title !== "Untitled") return note.title;
+    return deriveTitleAndPreview(note.content).title || note.title || "Untitled";
+}
+
 function escapeHtml(str: string): string {
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// Only allow safe link protocols on public pages. An edit-share collaborator
+// (or pasted content) can put a javascript:/data: URL in a link href; without
+// this it executes on the owner's *.notty.page origin for every reader.
+function safeUrl(raw: string): string {
+    const url = (raw || "").trim();
+    if (/^javascript:/i.test(url) || /^data:/i.test(url) || /^vbscript:/i.test(url)) return "#";
+    if (/^(https?:\/\/|mailto:|\/|#|\.)/i.test(url)) return url;
+    return "#";
 }
 
 function formatDate(timestamp: number): string {
@@ -46,7 +65,9 @@ function renderNode(node: any, userId: string): string {
         case "paragraph":
             return `<p>${children || "<br>"}</p>`;
         case "heading": {
-            const level = node.attrs?.level || 2;
+            // Clamp — attrs.level is client-controllable via Yjs and would
+            // otherwise inject arbitrary markup into the tag name.
+            const level = Math.min(6, Math.max(1, parseInt(node.attrs?.level, 10) || 2));
             return `<h${level}>${children}</h${level}>`;
         }
         case "text": {
@@ -58,7 +79,7 @@ function renderNode(node: any, userId: string): string {
                     case "underline": text = `<u>${text}</u>`; break;
                     case "strike": text = `<s>${text}</s>`; break;
                     case "code": text = `<code>${text}</code>`; break;
-                    case "link": text = `<a href="${escapeHtml(mark.attrs?.href || "")}" rel="noopener">${text}</a>`; break;
+                    case "link": text = `<a href="${escapeHtml(safeUrl(mark.attrs?.href || ""))}" rel="noopener nofollow">${text}</a>`; break;
                 }
             }
             return text;
@@ -181,13 +202,13 @@ export function renderPublicPage(profile: any, notes: any[], baseUrl: string): s
     const userId = profile.user_id || "";
     const entries = notes.map((note: any) => {
         const date = note.published_at ? formatDate(note.published_at) : "";
-        const noteTitle = escapeHtml(note.title || "Untitled");
+        const noteTitle = escapeHtml(publicNoteTitle(note));
         const html = tiptapToHtml(note.content, true, userId);
         const folderName = note.folder_name ? escapeHtml(note.folder_name) : "";
         return `
             <article>
                 <div class="date">${[date, folderName].filter(Boolean).join(" · ")}</div>
-                <h2><a href="${baseUrl}/${note.id}">${noteTitle}</a></h2>
+                <h2><a href="${baseUrl}/${escapeHtml(String(note.id))}">${noteTitle}</a></h2>
                 <div class="content">${html}</div>
             </article>`;
     }).join("\n<hr>\n");
@@ -221,7 +242,7 @@ export function renderPublicPage(profile: any, notes: any[], baseUrl: string): s
 
 export function renderPublicNote(profile: any, note: any, baseUrl: string): string {
     const pageTitle = escapeHtml(profile.page_title || "My Notes");
-    const noteTitle = escapeHtml(note.title || "Untitled");
+    const noteTitle = escapeHtml(publicNoteTitle(note));
     const date = note.published_at ? formatDate(note.published_at) : "";
     const html = tiptapToHtml(note.content, true, profile.user_id || "");
     const font = profile.font || "serif";

--- a/src/server/rss.ts
+++ b/src/server/rss.ts
@@ -1,3 +1,5 @@
+import { publicNoteTitle } from "./public-page";
+
 function escapeXml(str: string): string {
     return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
@@ -26,7 +28,12 @@ function renderNode(node: any): string {
     const children = node.content ? renderNodes(node.content) : "";
     switch (node.type) {
         case "paragraph": return `<p>${children}</p>`;
-        case "heading": return `<h${node.attrs?.level || 2}>${children}</h${node.attrs?.level || 2}>`;
+        case "heading": {
+            // attrs.level is client-controllable via Yjs — clamp to a real
+            // heading level, never interpolate it raw into the tag name.
+            const level = Math.min(6, Math.max(1, parseInt(node.attrs?.level, 10) || 2));
+            return `<h${level}>${children}</h${level}>`;
+        }
         case "text": {
             let text = escapeXml(node.text || "");
             for (const mark of node.marks || []) {
@@ -50,13 +57,13 @@ export function renderRSS(profile: any, notes: any[], baseUrl: string): string {
     const description = escapeXml(profile.page_description || "");
 
     const items = notes.map((note: any) => {
-        const noteTitle = escapeXml(note.title || "Untitled");
+        const noteTitle = escapeXml(publicNoteTitle(note));
         const html = tiptapToPlainHtml(note.content, true);
         const pubDate = note.published_at ? toRfc822(note.published_at) : "";
         return `    <item>
       <title>${noteTitle}</title>
-      <link>${baseUrl}/${note.id}</link>
-      <guid isPermaLink="true">${baseUrl}/${note.id}</guid>
+      <link>${baseUrl}/${escapeXml(String(note.id))}</link>
+      <guid isPermaLink="true">${baseUrl}/${escapeXml(String(note.id))}</guid>
       ${pubDate ? `<pubDate>${pubDate}</pubDate>` : ""}
       <description><![CDATA[${html}]]></description>
     </item>`;


### PR DESCRIPTION
Fixes the "published note is blank/Untitled" report and a cluster of sibling reliability bugs surfaced by a follow-up audit (server/DO, client sync, public surfaces).

## The reported bug
Published notes rendered blank/"Untitled" because `Y.XmlFragment`/`Y.XmlElement` aren't iterable — `Array.from()` yielded `undefined`s, so the Durable Object serialized every note to an empty doc and the 2s debounced save wiped the real content column. Fixed with `.toArray()`, a guard so an empty doc can't overwrite non-empty content, and a publish that refuses empty content (409). The tolerated tsc errors in `user-notes.ts` were flagging exactly this.

## Data loss / sync
- Evict the stale cached `Y.Doc` when a no-active-Yjs HTTP save nulls `yjs_state`, so the next WS connect can't serve+repersist old state over newer content.
- `flushPendingSave` now persists content+title (not just `yjs_state`) via a shared `persistDocNow`; debounced save retries with backoff instead of dropping edits on a transient failure.
- checkout/merge reconstruct strictly (503 on R2 blip) + take a pre-op auto-backup.
- Client: WS close 4000 sets a `reset` flag + fires `onContentReset` so an evicted editor stops saving and remounts, instead of re-uploading its stale doc and clobbering a remote restore.
- Editor seeds HTTP content immediately only when `/meta` confirms the note was never initialized, else waits for sync (bounded) — closes the CRDT-doubling window on meta-fetch failure.
- `notes-context` optimistic timestamps in seconds (were ms) + reconcile from the server save response, so local edits no longer pin stale copies forever.

## Security / privacy
- `save-note` (WS) and `PUT /notes` pin writes to the authorized note id — an edit-share collaborator could previously overwrite *any* of the owner's notes.
- Public pages: allowlist link protocols (block `javascript:`), clamp heading level, escape client-supplied note ids in hrefs/GUIDs.
- Trashing a note unpublishes it; public route 404s deleted notes.
- `note-updated` broadcasts go to owner sockets only (were leaking full note content to view-only visitors).
- Subdomain router lets `/api`, `/assets`, favicon, robots through — fixes broken images on published blog pages.

## UI
- `PublishToggle` early-return moved below hooks (rules-of-hooks crash on anon→signed-in flip).
- Quick-note widget survives a load failure instead of hanging on "Loading…"; publish surfaces failures as a toast.

## Verification
`scripts/qa-publish-race.ts` (publish race → 200, versions coalesced), renderer unit tests (6 XSS/injection vectors neutralized), cross-note PUT attack blocked, trashed note → `published=0`+`deleted_at`, and an aside-browser type→reload round-trip showing content persists exactly once (no doubling). Typecheck and build clean.

## Known follow-ups (not in this PR)
Lock enforcement still missing on the HTTP `PUT` path; `simpleHmac` lock token is FNV not a real HMAC; version pruning can delete a branch head in edge cases; OG-image generation has no failure fallback. None cause silent data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/4dbfc77f-4994-4d00-ae23-bc95d055b3f4)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
